### PR TITLE
Switch logging component

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = external/CLI11
 	url = https://github.com/CLIUtils/CLI11.git
 	branch = master
+[submodule "external/plog"]
+	path = external/plog
+	url = https://github.com/SergiusTheBest/plog.git
+	branch = master

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -33,6 +33,8 @@ target_include_directories(
 
 target_include_directories(
     ${MMOTD_TARGET_NAME} SYSTEM
+    PRIVATE ${CMAKE_SOURCE_DIR}/external/plog/include
+    PRIVATE ${CMAKE_SOURCE_DIR}/external/CLI11/include
     PRIVATE ${Boost_INCLUDE_DIRS}
     )
 
@@ -51,31 +53,5 @@ target_link_libraries(
     PRIVATE ${OPENSSL_CRYPTO_LIBRARY}
     PRIVATE ${OPENSSL_SSL_LIBRARY}
     PRIVATE ZLIB::ZLIB
-    PRIVATE CLI11::CLI11
-    PRIVATE ${Boost_LIBRARIES}
     )
 
-# TODO: may need some of the following ideas when coming back to get macOS
-#       brew version of GCC to compile the project.
-
-#target_link_libraries(${MMOTD_TARGET_NAME} -Wl,--start-group ${Boost_LIBRARIES} -Wl,--end-group)
-#target_link_libraries(${mmotd_target_name} PRIVATE Boost::log INTERFACE ${loglib})
-
-#target_link_options(
-#    ${MMOTD_TARGET_NAME}
-#    -Wl,--start-group
-#    ${Boost_LIBRARIES}
-#    -Wl,--end-group
-#    )
-
-
-    #PRIVATE Boost::log
-    #INTERFACE ${loglib}
-    #PRIVATE ${Boost_LIBRARIES}
-    #PRIVATE /usr/local/lib/libboost_atomic-mt.dylib
-    #PRIVATE /usr/local/lib/libboost_chrono-mt.dylib
-    #PRIVATE /usr/local/lib/libboost_regex-mt.dylib
-    #PRIVATE /usr/local/lib/libboost_thread-mt.dylib
-    #PRIVATE /usr/local/lib/libboost_filesystem-mt.dylib
-    #PRIVATE /usr/local/lib/libboost_date_time-mt.dylib
-    #PRIVATE /usr/local/lib/libboost_log-mt.dylib

--- a/app/include/logging.h
+++ b/app/include/logging.h
@@ -2,11 +2,22 @@
 #pragma once
 
 #include <string>
+#include <plog/Log.h>
 
 namespace Logging {
+
+const constexpr int CONSOLE_LOG = 1;
 
 void DefaultInitializeLogging();
 void InitializeLogging(const std::string &ini_file);
 void UpdateSeverityFilter(int severity);
 
 } // namespace Logging
+
+#define MMOTD_LOG_VERBOSE                     PLOG(plog::verbose); PLOG(Logging::CONSOLE_LOG, plog::verbose)
+#define MMOTD_LOG_DEBUG                       PLOG(plog::debug); PLOG(Logging::CONSOLE_LOG, plog::debug)
+#define MMOTD_LOG_INFO                        PLOG(plog::info); PLOG(Logging::CONSOLE_LOG, plog::info)
+#define MMOTD_LOG_WARNING                     PLOG(plog::warning); PLOG(Logging::CONSOLE_LOG, plog::warning)
+#define MMOTD_LOG_ERROR                       PLOG(plog::error); PLOG(Logging::CONSOLE_LOG, plog::error)
+#define MMOTD_LOG_FATAL                       PLOG(plog::fatal); PLOG(Logging::CONSOLE_LOG, plog::fatal)
+#define MMOTD_LOG_NONE                        PLOG(plog::none); PLOG(Logging::CONSOLE_LOG, plog::none)

--- a/app/include/logging.h
+++ b/app/include/logging.h
@@ -1,8 +1,8 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
 
-#include <string>
 #include <plog/Log.h>
+#include <string>
 
 namespace Logging {
 
@@ -14,10 +14,24 @@ void UpdateSeverityFilter(int severity);
 
 } // namespace Logging
 
-#define MMOTD_LOG_VERBOSE                     PLOG(plog::verbose); PLOG(Logging::CONSOLE_LOG, plog::verbose)
-#define MMOTD_LOG_DEBUG                       PLOG(plog::debug); PLOG(Logging::CONSOLE_LOG, plog::debug)
-#define MMOTD_LOG_INFO                        PLOG(plog::info); PLOG(Logging::CONSOLE_LOG, plog::info)
-#define MMOTD_LOG_WARNING                     PLOG(plog::warning); PLOG(Logging::CONSOLE_LOG, plog::warning)
-#define MMOTD_LOG_ERROR                       PLOG(plog::error); PLOG(Logging::CONSOLE_LOG, plog::error)
-#define MMOTD_LOG_FATAL                       PLOG(plog::fatal); PLOG(Logging::CONSOLE_LOG, plog::fatal)
-#define MMOTD_LOG_NONE                        PLOG(plog::none); PLOG(Logging::CONSOLE_LOG, plog::none)
+#define MMOTD_LOG_VERBOSE \
+    PLOG(plog::verbose);  \
+    PLOG(Logging::CONSOLE_LOG, plog::verbose)
+#define MMOTD_LOG_DEBUG \
+    PLOG(plog::debug);  \
+    PLOG(Logging::CONSOLE_LOG, plog::debug)
+#define MMOTD_LOG_INFO \
+    PLOG(plog::info);  \
+    PLOG(Logging::CONSOLE_LOG, plog::info)
+#define MMOTD_LOG_WARNING \
+    PLOG(plog::warning);  \
+    PLOG(Logging::CONSOLE_LOG, plog::warning)
+#define MMOTD_LOG_ERROR \
+    PLOG(plog::error);  \
+    PLOG(Logging::CONSOLE_LOG, plog::error)
+#define MMOTD_LOG_FATAL \
+    PLOG(plog::fatal);  \
+    PLOG(Logging::CONSOLE_LOG, plog::fatal)
+#define MMOTD_LOG_NONE \
+    PLOG(plog::none);  \
+    PLOG(Logging::CONSOLE_LOG, plog::none)

--- a/app/src/cli_app_options_creator.cpp
+++ b/app/src/cli_app_options_creator.cpp
@@ -6,13 +6,13 @@
 #include <algorithm>
 #include <any>
 #include <boost/algorithm/string.hpp>
-#include <plog/Log.h>
 #include <filesystem>
 #include <fmt/format.h>
 #include <fstream>
 #include <functional>
 #include <iterator>
 #include <memory>
+#include <plog/Log.h>
 #include <sstream>
 #include <stdexcept>
 

--- a/app/src/cli_app_options_creator.cpp
+++ b/app/src/cli_app_options_creator.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <any>
 #include <boost/algorithm/string.hpp>
-#include <boost/log/trivial.hpp>
+#include <plog/Log.h>
 #include <filesystem>
 #include <fmt/format.h>
 #include <fstream>
@@ -47,16 +47,16 @@ void CliAppOptionsCreator::Parse(const int argc, char **argv) {
         app_finished_ = false;
     } catch (const CLI::CallForHelp &help) {
         const auto &msg = app.help("", CLI::AppFormatMode::All);
-        BOOST_LOG_TRIVIAL(info) << msg;
+        PLOG_INFO << msg;
         cout << msg << endl;
     } catch (const CLI::CallForVersion &version) {
         const string msg = format("version: {}", version.what());
-        BOOST_LOG_TRIVIAL(info) << msg;
+        PLOG_INFO << msg;
         cout << msg << endl;
     } catch (const CLI::ParseError &err) {
         // TODO: move this actual error all the way to main where we can actually use the error code
         if (err.get_exit_code() != 0) {
-            BOOST_LOG_TRIVIAL(error) << format("error code {}: {}", err.get_exit_code(), err.what());
+            PLOG_ERROR << format("error code {}: {}", err.get_exit_code(), err.what());
             cerr << format("ERROR ({}): {}\n", err.get_exit_code(), err.what());
         }
     }
@@ -65,7 +65,7 @@ void CliAppOptionsCreator::Parse(const int argc, char **argv) {
         new_config << app.config_to_str(true, true);
         app_finished_ = true;
     }
-    BOOST_LOG_TRIVIAL(debug) << "Options:\n" << to_string(options_) << endl;
+    PLOG_DEBUG << "Options:\n" << to_string(options_) << endl;
 }
 
 void CliAppOptionsCreator::AddOptionDeclarations(CLI::App &app) {

--- a/app/src/color.cpp
+++ b/app/src/color.cpp
@@ -1,7 +1,7 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "app/include/color.h"
 
-#include <boost/log/trivial.hpp>
+#include <plog/Log.h>
 #include <fmt/format.h>
 
 #include <algorithm>
@@ -194,7 +194,7 @@ void PrintErrorInternal(ostream &out, std::string msg, bool tee_to_log) {
         out << "\n";
     }
     if (tee_to_log) {
-        BOOST_LOG_TRIVIAL(error) << msg;
+        PLOG_ERROR << msg;
     }
 }
 
@@ -206,7 +206,7 @@ void PrintErrorInternal(ostream &out, const char *msg, bool tee_to_log) {
         out << "\n";
     }
     if (tee_to_log) {
-        BOOST_LOG_TRIVIAL(error) << msg;
+        PLOG_ERROR << msg;
     }
 }
 
@@ -219,7 +219,7 @@ void PrintErrorInternal(ostream &out, std::string_view msg, bool tee_to_log) {
         out << "\n";
     }
     if (tee_to_log) {
-        BOOST_LOG_TRIVIAL(error) << msg;
+        PLOG_ERROR << msg;
     }
 }
 
@@ -231,7 +231,7 @@ void PrintInfoInternal(ostream &out, string msg, bool tee_to_log) {
         out << "\n";
     }
     if (tee_to_log) {
-        BOOST_LOG_TRIVIAL(info) << msg;
+        PLOG_INFO << msg;
     }
 }
 
@@ -243,7 +243,7 @@ void PrintInfoInternal(ostream &out, const char *msg, bool tee_to_log) {
         out << "\n";
     }
     if (tee_to_log) {
-        BOOST_LOG_TRIVIAL(info) << msg;
+        PLOG_INFO << msg;
     }
 }
 
@@ -256,7 +256,7 @@ void PrintInfoInternal(ostream &out, std::string_view msg, bool tee_to_log) {
         out << "\n";
     }
     if (tee_to_log) {
-        BOOST_LOG_TRIVIAL(info) << msg;
+        PLOG_INFO << msg;
     }
 }
 

--- a/app/src/color.cpp
+++ b/app/src/color.cpp
@@ -1,8 +1,8 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "app/include/color.h"
 
-#include <plog/Log.h>
 #include <fmt/format.h>
+#include <plog/Log.h>
 
 #include <algorithm>
 #include <array>

--- a/app/src/logging.cpp
+++ b/app/src/logging.cpp
@@ -1,12 +1,11 @@
 #include "app/include/logging.h"
 
-#include <boost/log/core.hpp>
-#include <boost/log/trivial.hpp>
-#include <boost/log/utility/setup/common_attributes.hpp>
-#include <boost/log/utility/setup/filter_parser.hpp>
-#include <boost/log/utility/setup/from_settings.hpp>
-#include <boost/log/utility/setup/from_stream.hpp>
-#include <boost/log/utility/setup/settings.hpp>
+#include <plog/Log.h>
+#include <plog/Init.h>
+#include <plog/Formatters/TxtFormatter.h>
+#include <plog/Appenders/ColorConsoleAppender.h>
+#include <plog/Appenders/RollingFileAppender.h>
+
 #include <cassert>
 #include <cstddef>
 #include <filesystem>
@@ -16,84 +15,23 @@
 #include <string>
 #include <utility>
 
-namespace logging = boost::log;
 using fmt::format;
 using namespace std;
-
-struct CoreLoggerSwitch {
-    CoreLoggerSwitch(bool turn_off_logging = true) : logging_off_(turn_off_logging) {
-        // cout << format("INFO: CoreLoggerSwitch ctor turning logging {}\n", !logging_off_ ? "on" : "off");
-        logging::core::get()->set_logging_enabled(!logging_off_);
-    }
-    ~CoreLoggerSwitch() {
-        // cout << format("INFO: CoreLoggerSwitch dtor turning logging {}\n", logging_off_ ? "on" : "off");
-        logging::core::get()->set_logging_enabled(logging_off_);
-    }
-
-private:
-    bool logging_off_ = true;
-};
 
 template<typename... Args>
 inline void unused(Args &&...) {
 }
 
-static void SetupLoggingFromFile(const string &ini_file) {
-    assert(filesystem::exists(ini_file));
-    // cout << format("INFO: loading logging settings from {}\n", ini_file);
-
-    auto ini_stream = ifstream(ini_file);
-    unused(CoreLoggerSwitch{});
-    logging::core::get()->remove_all_sinks();
-    logging::init_from_stream(ini_stream);
-    logging::add_common_attributes();
-    logging::core::get()->set_logging_enabled(true);
-}
-
 void Logging::DefaultInitializeLogging() {
-    // cout << "INFO: loading logging settings from hard-coded definitions\n";
-
-    logging::settings setts;
-    setts["Core"]["Filter"] = "%Severity% >= debug";
-    setts["Core"]["DisableLogging"] = false;
-
-    setts["Sinks.Console"]["Destination"] = "Console";
-    setts["Sinks.Console"]["Filter"] = "%Severity% >= critical";
-    setts["Sinks.Console"]["Format"] = "%TimeStamp% [%Severity%] %Message%";
-    setts["Sinks.Console"]["AutoNewline"] = "InsertIfMissing";
-    setts["Sinks.Console"]["Asynchronous"] = false;
-    setts["Sinks.Console"]["AutoFlush"] = true;
-
-    setts["Sinks.File"]["Destination"] = "TextFile";
-    setts["Sinks.File"]["FileName"] = "mmotd_%3N.log";
-    // setts["Sinks.File"]["Target"] = "/Users/jasoni/dev/";
-    setts["Sinks.File"]["AutoFlush"] = true;
-    setts["Sinks.File"]["AutoNewline"] = "InsertIfMissing";
-    setts["Sinks.File"]["RotationSize"] = 10 * 1024 * 1024; // 10 MiB
-    setts["Sinks.File"]["Format"] = "%TimeStamp% [%Severity%] %Message%";
-    setts["Sinks.File"]["Append"] = true;
-
-    logging::init_from_settings(setts);
-    logging::add_common_attributes();
+    static auto file_appender = plog::RollingFileAppender<plog::TxtFormatter>("mmotd.log", 5 * 1048576, 3);
+    static auto console_appender = plog::ColorConsoleAppender<plog::TxtFormatter>{};
+    plog::init(plog::verbose, &file_appender);
+    plog::init<CONSOLE_LOG>(plog::warning, &console_appender);
 }
 
-void Logging::InitializeLogging(const string &ini_file) {
-    if (filesystem::exists(ini_file)) {
-        SetupLoggingFromFile(ini_file);
-    } else {
-        cerr << format("ERROR: logging ini does not exist {}\n", ini_file);
-        DefaultInitializeLogging();
-    }
+void Logging::InitializeLogging(const string & /*ini_file*/) {
+    DefaultInitializeLogging();
 }
 
-void Logging::UpdateSeverityFilter(int verbosity) {
-    using namespace logging::trivial;
-    unused(CoreLoggerSwitch{});
-    auto error_log_level = static_cast<int>(error);
-    auto new_log_level = static_cast<severity_level>(std::max(error_log_level - verbosity, 0));
-    auto filter_str = format("%Severity% >= {}", to_string(new_log_level));
-    auto filter = logging::parse_filter(filter_str);
-    logging::core::get()->set_filter(filter);
-    // logging::core::get()->set_filter(logging::expressions::attr<boost::log::trivial::severity_level>("Severity") >=
-    // new_log_level); logging::core::get()->set_filter(severity_level >= new_log_level);
+void Logging::UpdateSeverityFilter(int /*verbosity*/) {
 }

--- a/app/src/logging.cpp
+++ b/app/src/logging.cpp
@@ -1,10 +1,10 @@
 #include "app/include/logging.h"
 
-#include <plog/Log.h>
-#include <plog/Init.h>
-#include <plog/Formatters/TxtFormatter.h>
 #include <plog/Appenders/ColorConsoleAppender.h>
 #include <plog/Appenders/RollingFileAppender.h>
+#include <plog/Formatters/TxtFormatter.h>
+#include <plog/Init.h>
+#include <plog/Log.h>
 
 #include <cassert>
 #include <cstddef>

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -13,7 +13,6 @@
 #include "app/include/logging.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/log/trivial.hpp>
 #include <cstdlib>
 #include <fmt/format.h>
 #include <iostream>

--- a/cmake/find_dependencies.cmake
+++ b/cmake/find_dependencies.cmake
@@ -13,11 +13,7 @@ endif ()
 find_package(ZLIB 1.2.11 REQUIRED)
 
 find_package(fmt)
-set (Boost_USE_STATIC_LIBS off)
-set (Boost_USE_MULTITHREADED on)
-set (Boost_USE_STATIC_RUNTIME off)
-add_definitions(-DBOOST_ALL_DYN_LINK ${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
-find_package(Boost 1.74.0 REQUIRED COMPONENTS log_setup log)
+find_package(Boost 1.74.0 REQUIRED)
 
 # Find OpenSSL for use with boost::asio and boost::beast.
 #  There is also a submodule certify which handles the https
@@ -42,6 +38,4 @@ if (GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
         endif ()
     endif ()
 endif ()
-
-add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/external/CLI11)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -38,5 +38,6 @@ target_include_directories(
     PRIVATE ${Boost_INCLUDE_DIRS}
     PRIVATE ${OPENSSL_INCLUDE_DIR}
     PRIVATE ${CMAKE_SOURCE_DIR}/external/certify/include
+    PRIVATE ${CMAKE_SOURCE_DIR}/external/plog/include
     )
 

--- a/lib/src/app_options.cpp
+++ b/lib/src/app_options.cpp
@@ -3,7 +3,6 @@
 #include "lib/include/app_options_creator.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/log/trivial.hpp>
 #include <fmt/format.h>
 #include <iostream>
 #include <string_view>
@@ -93,79 +92,6 @@ std::string Options::to_string() const {
     return options_str;
 }
 
-#ifdef _USING_BOOST_PROGRAM_OPTIONS
-static vector<size_t> InitializeTags() {
-    return {typeid(char).hash_code(),
-            typeid(int8_t).hash_code(),
-            typeid(uint8_t).hash_code(),
-            typeid(int16_t).hash_code(),
-            typeid(uint16_t).hash_code(),
-            typeid(int32_t).hash_code(),
-            typeid(uint32_t).hash_code(),
-            typeid(int64_t).hash_code(),
-            typeid(uint64_t).hash_code(),
-            typeid(float).hash_code(),
-            typeid(double).hash_code(),
-            typeid(string).hash_code(),
-            typeid(string_view).hash_code()};
-}
-vector<size_t> Option::OptionTypeTags = InitializeTags();
-
-std::string Option::to_string() const {
-    return format("[{}] {} {}", is_set ? "SET" : "UNSET", name, ::to_string(value));
-}
-#endif
-
-#if 0
-string to_string(const any &value) {
-    if (!value.has_value()) {
-        return string{};
-    } else if (value.type().hash_code() == typeid(char).hash_code()) {
-        auto converted_value = any_cast<char>(value);
-        return to_string(converted_value);
-    } else if (value.type().hash_code() == typeid(int8_t).hash_code()) {
-        auto converted_value = any_cast<int8_t>(value);
-        return to_string(converted_value);
-    } else if (value.type().hash_code() == typeid(uint8_t).hash_code()) {
-        auto converted_value = any_cast<uint8_t>(value);
-        return to_string(converted_value);
-    } else if (value.type().hash_code() == typeid(int16_t).hash_code()) {
-        auto converted_value = any_cast<int16_t>(value);
-        return to_string(converted_value);
-    } else if (value.type().hash_code() == typeid(uint16_t).hash_code().hash_code()) {
-        auto converted_value = any_cast<uint16_t>(value);
-        return to_string(converted_value);
-    } else if (value.type().hash_code() == typeid(int32_t).hash_code()) {
-        auto converted_value = any_cast<int32_t>(value);
-        return to_string(converted_value);
-    } else if (value.type().hash_code() == typeid(uint32_t).hash_code()) {
-        auto converted_value = any_cast<uint32_t>(value);
-        return to_string(converted_value);
-    } else if (value.type().hash_code() == typeid(int64_t).hash_code()) {
-        auto converted_value = any_cast<int64_t>(value);
-        return to_string(converted_value);
-    } else if (value.type().hash_code() == typeid(uint64_t).hash_code()) {
-        auto converted_value = any_cast<uint64_t>(value);
-        return to_string(converted_value);
-    } else if (value.type().hash_code() == typeid(float).hash_code()) {
-        auto converted_value = any_cast<float>(value);
-        return to_string(converted_value);
-    } else if (value.type().hash_code() == typeid(double).hash_code()) {
-        auto converted_value = any_cast<double>(value);
-        return to_string(converted_value);
-    } else if (value.type().hash_code() == typeid(string).hash_code()) {
-        return any_cast<string>(value);
-    } else if (value.type().hash_code() == typeid(string_view).hash_code()) {
-        return string{any_cast<string_view>(value)};
-    } else {
-        const auto error_val = format("unknown std::any type {}", value.type().name());
-        BOOST_LOG_TRIVIAL(error) << error_val;
-        throw std::runtime_error{error_val};
-    }
-    return string{};
-}
-#endif
-
 const AppOptions *AppOptions::Initialize(const AppOptionsCreator &creator) {
     static auto app_options = AppOptions{};
     app_options.AddOptions(creator);
@@ -175,14 +101,3 @@ const AppOptions *AppOptions::Initialize(const AppOptionsCreator &creator) {
 void AppOptions::AddOptions(const AppOptionsCreator &creator) {
     options_ = creator.GetOptions();
 }
-
-/*
-std::any AppOptions::GetOption(const std::string &name) const {
-    auto i = find_if(begin(options_), end(options_), [&name](const auto &option) {
-        return boost::iequals(name, option.name);
-    });
-    return i != end(options_) ? i->value : std::any{};
-}
-
-bool AppOptions::IsHelpNeeded() const { return false; }
-*/

--- a/lib/src/external_network.cpp
+++ b/lib/src/external_network.cpp
@@ -2,10 +2,10 @@
 #include "lib/include/external_network.h"
 #include "lib/include/http_request.h"
 
-#include <plog/Log.h>
-#include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include <json/json.h>
+#include <plog/Log.h>
 #include <sstream>
 #include <tuple>
 
@@ -35,7 +35,7 @@ IpAddress ExternalNetwork::ParseJsonResponse(const string &response) {
     auto tree = pt::ptree{};
     pt::read_json(input_stream, tree);
 
-    //walk_ptree(tree, 2);
+    // walk_ptree(tree, 2);
     if (tree.empty()) {
         PLOG_ERROR << "http response is empty after converting to json";
     } else {

--- a/lib/src/external_network.cpp
+++ b/lib/src/external_network.cpp
@@ -2,10 +2,7 @@
 #include "lib/include/external_network.h"
 #include "lib/include/http_request.h"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated"
-
-#include <boost/log/trivial.hpp>
+#include <plog/Log.h>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <json/json.h>
@@ -40,12 +37,11 @@ IpAddress ExternalNetwork::ParseJsonResponse(const string &response) {
 
     //walk_ptree(tree, 2);
     if (tree.empty()) {
-        BOOST_LOG_TRIVIAL(error)
-            << "converting HTTP response from ipinfo to JSON. Conversion succeeded but the value is empty";
+        PLOG_ERROR << "http response is empty after converting to json";
     } else {
         auto ip_address_value = tree.get_optional<string>("ip");
         if (ip_address_value) {
-            BOOST_LOG_TRIVIAL(info) << "found ip address in json response body=" << *ip_address_value << "\n";
+            PLOG_INFO << "found ip address in json response body=" << *ip_address_value << "\n";
             return make_address(*ip_address_value);
         }
     }
@@ -57,7 +53,7 @@ bool ExternalNetwork::TryDiscovery() {
     // const auto response = request.MakeRequest("/json?token=YOUR_TOKEN_HERE");
     const auto response = request.MakeRequest("/json");
     if (response.empty()) {
-        BOOST_LOG_TRIVIAL(error) << "querying 'http://ipinfo.io/json' failed";
+        PLOG_ERROR << "querying 'http://ipinfo.io/json' failed";
         return false;
     }
     const auto ip_address = ParseJsonResponse(response);
@@ -66,4 +62,3 @@ bool ExternalNetwork::TryDiscovery() {
     }
     return !ip_address.is_unspecified();
 }
-#pragma GCC diagnostic pop

--- a/lib/src/http_request.cpp
+++ b/lib/src/http_request.cpp
@@ -9,9 +9,9 @@
 #include <boost/beast/version.hpp>
 #include <boost/exception/all.hpp>
 #include <boost/system/error_code.hpp>
-#include <plog/Log.h>
 #include <cstdlib>
 #include <fmt/format.h>
+#include <plog/Log.h>
 #include <string>
 
 namespace beast = boost::beast; // from <boost/beast.hpp>
@@ -79,19 +79,22 @@ optional<string> HttpRequest::TryMakeRequest(std::string path) {
         http::read(stream, buffer, response);
     } catch (boost::system::error_code &ec) {
         if (ec == http::error::end_of_stream) {
-            PLOG_INFO << format(
-                "ignoring 'http::error::end_of_stream' during http request of {}:{}{} (details: {})",
-                host_,
-                port_,
-                path,
-                ec.message());
+            PLOG_INFO << format("ignoring 'http::error::end_of_stream' during http request of {}:{}{} (details: {})",
+                                host_,
+                                port_,
+                                path,
+                                ec.message());
             ec = boost::system::error_code{};
         } else {
             PLOG_ERROR << format("during http request of {}:{}{}, {}", host_, port_, path, ec.message());
             return nullopt;
         }
     } catch (boost::exception &ex) {
-        PLOG_ERROR << format("during http request of {}:{}{} (details: {})", host_, port_, path, boost::diagnostic_information(ex));
+        PLOG_ERROR << format("during http request of {}:{}{} (details: {})",
+                             host_,
+                             port_,
+                             path,
+                             boost::diagnostic_information(ex));
         return nullopt;
     } catch (std::exception &ex) {
         PLOG_ERROR << format("during http request of {}:{}{} (details: {})", host_, port_, path, ex.what());
@@ -99,7 +102,9 @@ optional<string> HttpRequest::TryMakeRequest(std::string path) {
     }
 
     if (response.result() != http::status::ok) {
-        PLOG_ERROR << format("http request status != 200, status: {}, reason: {}", response.result_int(), response.reason().to_string());
+        PLOG_ERROR << format("http request status != 200, status: {}, reason: {}",
+                             response.result_int(),
+                             response.reason().to_string());
         return nullopt;
     }
 

--- a/lib/src/http_secure_request.cpp
+++ b/lib/src/http_secure_request.cpp
@@ -13,8 +13,8 @@
 #include <boost/certify/extensions.hpp>
 #include <boost/certify/https_verification.hpp>
 
-#include <plog/Log.h>
 #include <fmt/format.h>
+#include <plog/Log.h>
 
 namespace beast = boost::beast;
 namespace asio = boost::asio;

--- a/lib/src/http_secure_request.cpp
+++ b/lib/src/http_secure_request.cpp
@@ -13,7 +13,7 @@
 #include <boost/certify/extensions.hpp>
 #include <boost/certify/https_verification.hpp>
 
-#include <boost/log/trivial.hpp>
+#include <plog/Log.h>
 #include <fmt/format.h>
 
 namespace beast = boost::beast;
@@ -23,6 +23,7 @@ namespace http = boost::beast::http;
 using tcp = boost::asio::ip::tcp;
 using ssl_stream = ssl::stream<tcp::socket>;
 using stream_ptr = std::unique_ptr<ssl_stream>;
+using fmt::format;
 using namespace std;
 
 namespace {
@@ -39,11 +40,8 @@ tcp::socket connect(asio::io_context &ctx, std::string const &hostname) {
 
 stream_ptr connect(asio::io_context &ctx, ssl::context &ssl_ctx, std::string const &hostname) {
     auto stream = boost::make_unique<ssl_stream>(connect(ctx, hostname), ssl_ctx);
-    // tag::stream_setup_source[]
     boost::certify::set_server_hostname(*stream, hostname);
     boost::certify::sni_hostname(*stream, hostname);
-    // end::stream_setup_source[]
-
     stream->handshake(ssl::stream_base::handshake_type::client);
     return stream;
 }
@@ -69,16 +67,17 @@ optional<string> HttpRequest::TryMakeSecureRequest(string path) {
     ssl::context ssl_ctx{ssl::context::tls_client};
     ssl_ctx.set_verify_mode(ssl::context::verify_peer | ssl::context::verify_fail_if_no_peer_cert);
     ssl_ctx.set_default_verify_paths();
-    // tag::ctx_setup_source[]
+
     boost::certify::enable_native_https_server_verification(ssl_ctx);
-    // end::ctx_setup_source[]
+
     auto stream = connect(ctx, ssl_ctx, host_);
     auto response = get(*stream, host_, path);
 
     auto response_str = response.body();
-    BOOST_LOG_TRIVIAL(info) << fmt::format("response from {}:{}{}\n{}", host_, port_, path, response_str);
+    PLOG_INFO << format("response from {}:{}{}\n{}", host_, port_, path, response_str);
 
-    boost::system::error_code ec;
+    auto ec = boost::system::error_code{};
+
     stream->shutdown(ec);
     stream->next_layer().close(ec);
 

--- a/lib/src/network.cpp
+++ b/lib/src/network.cpp
@@ -13,11 +13,11 @@
 
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
-#include <fmt/format.h>
-#include <plog/Log.h>
 #include <boost/numeric/conversion/cast.hpp>
+#include <fmt/format.h>
 #include <iostream>
 #include <optional>
+#include <plog/Log.h>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -131,13 +131,13 @@ string to_string(const IpAddresses &ip_addresses) {
 
 // bool get_mac_address(char* mac_addr, const char* if_name = "eth0")
 static optional<NetworkDevices> DiscoverNetworkDevices() {
-    //struct ifreq ifinfo;
-    //strcpy(ifinfo.ifr_name, if_name);
-    //int sd = socket(AF_INET, SOCK_DGRAM, 0);
-    //int result = ioctl(sd, SIOCGIFHWADDR, &ifinfo);
-    //close(sd);
+    // struct ifreq ifinfo;
+    // strcpy(ifinfo.ifr_name, if_name);
+    // int sd = socket(AF_INET, SOCK_DGRAM, 0);
+    // int result = ioctl(sd, SIOCGIFHWADDR, &ifinfo);
+    // close(sd);
 
-    //if ((result == 0) && (ifinfo.ifr_hwaddr.sa_family == 1)) {
+    // if ((result == 0) && (ifinfo.ifr_hwaddr.sa_family == 1)) {
     //    memcpy(mac_addr, ifinfo.ifr_hwaddr.sa_data, IFHWADDRLEN);
     //    return true;
     //} else {
@@ -169,10 +169,9 @@ static optional<NetworkDevices> DiscoverNetworkDevices() {
             const auto ntoa_str = string(link_ntoa(sock_addr));
             const auto index = ntoa_str.find(':');
             if (index == string::npos) {
-                PLOG_WARNING
-                    << format("{} found mac address {} which is not of the form interface:xx.xx.xx.xx.xx.xx",
-                              interface_name,
-                              ntoa_str);
+                PLOG_WARNING << format("{} found mac address {} which is not of the form interface:xx.xx.xx.xx.xx.xx",
+                                       interface_name,
+                                       ntoa_str);
                 continue;
             }
             auto iter = network_devices.find(interface_name);
@@ -185,9 +184,9 @@ static optional<NetworkDevices> DiscoverNetworkDevices() {
             auto mac_address = ntoa_str.substr(index + 1);
             if (static_cast<bool>(network_device->mac_address)) {
                 PLOG_WARNING << format("{} with mac address {} is being replaced with {}",
-                                                     interface_name,
-                                                     to_string(network_device->mac_address),
-                                                     mac_address);
+                                       interface_name,
+                                       to_string(network_device->mac_address),
+                                       mac_address);
             }
             network_device->mac_address = MacAddress(mac_address);
         } else if (address_family == AF_INET || address_family == AF_INET6) {
@@ -215,18 +214,14 @@ static optional<NetworkDevices> DiscoverNetworkDevices() {
             }
             auto ip_address = make_address(ip_str);
             if (ip_address.is_unspecified()) {
-                PLOG_INFO << format("{} with ip address {} is unspecified",
-                                                  interface_name,
-                                                  ip_address.to_string());
+                PLOG_INFO << format("{} with ip address {} is unspecified", interface_name, ip_address.to_string());
             } else if (ip_address.is_loopback()) {
-                PLOG_INFO << format("{} with ip address {} is loopback device",
-                                                  interface_name,
-                                                  ip_address.to_string());
+                PLOG_INFO << format("{} with ip address {} is loopback device", interface_name, ip_address.to_string());
             } else {
                 PLOG_INFO << format("{} with ip address {} is multicast device: {}",
-                                                  interface_name,
-                                                  ip_address.to_string(),
-                                                  ip_address.is_multicast() ? "yes" : "no");
+                                    interface_name,
+                                    ip_address.to_string(),
+                                    ip_address.is_multicast() ? "yes" : "no");
                 network_device->ip_addresses.push_back(ip_address);
             }
         }

--- a/lib/src/posix_sysctl_information.cpp
+++ b/lib/src/posix_sysctl_information.cpp
@@ -5,11 +5,8 @@
 //#include <sys/utsname.h>
 
 //#include <boost/algorithm/string.hpp>
-//#include <boost/log/trivial.hpp>
-//#include <fmt/format.h>
 #include <ostream>
 
-// using namespace fmt;
 using namespace std;
 
 ostream &operator<<(ostream &out, const PosixSysctlInformation &sysctl_info) {

--- a/lib/src/posix_system_information.cpp
+++ b/lib/src/posix_system_information.cpp
@@ -5,7 +5,7 @@
 #include <sys/utsname.h>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/log/trivial.hpp>
+#include <plog/Log.h>
 #include <fmt/format.h>
 #include <iostream>
 #include <optional>
@@ -28,9 +28,9 @@ static KernelDetails to_kernel_details(const string &kernel_type,
 static optional<KernelDetails> GetKernelDetails() {
     struct utsname buf = {};
     int retval = uname(&buf);
-    BOOST_LOG_TRIVIAL(debug) << format("uname returned {} [{}]", retval, retval == 0 ? "success" : "failed");
+    PLOG_DEBUG << format("uname returned {} [{}]", retval, retval == 0 ? "success" : "failed");
     if (retval != 0) {
-        BOOST_LOG_TRIVIAL(error) << format("uname failed with return code '{}'", retval);
+        PLOG_ERROR << format("uname failed with return code '{}'", retval);
         return optional<KernelDetails>{};
     }
 
@@ -40,11 +40,11 @@ static optional<KernelDetails> GetKernelDetails() {
     auto version = string(buf.version);
     auto machine = string(buf.machine);
 
-    BOOST_LOG_TRIVIAL(debug) << "sys name: " << sys_name;
-    BOOST_LOG_TRIVIAL(debug) << "node name: " << node_name;
-    BOOST_LOG_TRIVIAL(debug) << "release: " << release;
-    BOOST_LOG_TRIVIAL(debug) << "version: " << version;
-    BOOST_LOG_TRIVIAL(debug) << "machine: " << machine;
+    PLOG_DEBUG << "sys name: " << sys_name;
+    PLOG_DEBUG << "node name: " << node_name;
+    PLOG_DEBUG << "release: " << release;
+    PLOG_DEBUG << "version: " << version;
+    PLOG_DEBUG << "machine: " << machine;
 
     return to_kernel_details(sys_name, node_name, release, version, machine);
 }
@@ -232,7 +232,7 @@ static KernelRelease to_kernel_release(const string &release) {
     }
     if (release_parts.size() < 2) {
         auto error_str = format("uname release string is not of the format 'xx.yy' instead it is '{}'", release);
-        BOOST_LOG_TRIVIAL(error) << error_str;
+        PLOG_ERROR << error_str;
         throw std::runtime_error(error_str);
     }
     auto kernel_release = KernelRelease{};

--- a/lib/src/posix_system_information.cpp
+++ b/lib/src/posix_system_information.cpp
@@ -5,10 +5,10 @@
 #include <sys/utsname.h>
 
 #include <boost/algorithm/string.hpp>
-#include <plog/Log.h>
 #include <fmt/format.h>
 #include <iostream>
 #include <optional>
+#include <plog/Log.h>
 #include <sstream>
 
 using namespace fmt;

--- a/view/CMakeLists.txt
+++ b/view/CMakeLists.txt
@@ -42,3 +42,9 @@ target_include_directories(
     PRIVATE ${PROJECT_ROOT_INCLUDE_PATH}
     )
 
+target_include_directories(
+    ${MMOTD_TARGET_NAME} SYSTEM
+    PRIVATE ${CMAKE_SOURCE_DIR}/external/plog/include
+    PRIVATE ${Boost_INCLUDE_DIRS}
+    )
+


### PR DESCRIPTION
Closes #5 where I have removed the dependencies on `jsoncpp` an internal submodule of `fmt::format` and `boost::log`.  This makes it so the only external `.so` needed for linking is the ones for SSL http requests.