### PR TITLE
update-clang-format-include-sorting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -68,17 +68,41 @@ ContinuationIndentWidth: 4
 #  - foreach
 #  - Q_FOREACH
 #  - BOOST_FOREACH
-IncludeBlocks:   Preserve
+IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex:           '^(<|"(boost|CLI|fmt|json)/)'
-    Priority:        2
-    SortPriority:    0
-  - Regex:           '^"(app|lib|view)/include/)'
-    Priority:        3
-    SortPriority:    0
-  - Regex:           '.*'
-    Priority:        1
-    SortPriority:    0
+  # Your project's h files.
+  - Regex:    '^"(app|common|lib|view)/include/'
+    Priority: 10
+  # C++ system headers (as of C++17).
+  - Regex:    '^[<"](algorithm|any|array|atomic|bitset|cassert|ccomplex|cctype|cerrno|cfenv|cfloat|charconv|chrono|cinttypes|ciso646|climits|clocale|cmath|codecvt|complex|condition_variable|csetjmp|csignal|cstdalign|cstdarg|cstdbool|cstddef|cstdint|cstdio|cstdlib|cstring|ctgmath|ctime|cuchar|cwchar|cwctype|deque|exception|execution|filesystem|forward_list|fstream|functional|future|initializer_list|iomanip|ios|iosfwd|iostream|istream|iterator|limits|list|locale|map|memory|memory_resource|mutex|new|numeric|optional|ostream|queue|random|ratio|regex|scoped_allocator|set|shared_mutex|sstream|stack|stdexcept|streambuf|string|string_view|strstream|system_error|thread|tuple|type_traits|typeindex|typeinfo|unordered_map|unordered_set|utility|valarray|variant|vector)[">]$'
+    Priority: 20
+  # Boost headers
+  - Regex:    '^[<"]boost/'
+    Priority: 30
+  # fmt::format headers
+  - Regex:    '^[<"]fmt/'
+    Priority: 30
+  # plog headers
+  - Regex:    '^[<"]plog/'
+    Priority: 30
+  # CLI headers
+  - Regex:    '^[<"]CLI/'
+    Priority: 30
+  # Scope Guard headers
+  - Regex:    '^[<"]scope_guard.hpp[>"]'
+    Priority: 30
+  # C system headers.
+  - Regex:    '^[<"](aio|arpa/inet|assert|complex|cpio|ctype|curses|dirent|dlfcn|errno|fcntl|fenv|float|fmtmsg|fnmatch|ftw|glob|grp|iconv|ifaddrs|inttypes|iso646|langinfo|libgen|limits|locale|math|monetary|mqueue|ndbm|netdb|net/if|net/if_dl|netinet/in|netinet/tcp|nl_types|poll|pthread|pwd|regex|sched|search|semaphore|setjmp|signal|spawn|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|strings|stropts|sys/ipc|syslog|sys/mman|sys/msg|sys/resource|sys/select|sys/sem|sys/shm|sys/socket|sys/stat|sys/statvfs|sys/sysctl|sys/time|sys/times|sys/types|sys/uio|sys/un|sys/utsname|sys/wait|tar|term|termios|tgmath|threads|time|trace|uchar|ulimit|uncntrl|unistd|utime|utmpx|wchar|wctype|wordexp)\.h[">]$'
+    Priority: 60
+  # MacOS C system headers.
+  - Regex:    '^[<"](mach|mach-o|net|netinet|netinet6|nfs|pthread|readline|sys|uuid|vfs|xlocale)/'
+    Priority: 60
+  # Other libraries' h files (with angles).
+  - Regex:    '^<'
+    Priority: 70
+  # Other libraries' h files (with quotes).
+  - Regex:    '^"'
+    Priority: 80
 IncludeIsMainRegex: '\.cpp$'
 IncludeIsMainSourceRegex: '\.cpp$'
 IndentCaseLabels: true

--- a/app/include/logging.h
+++ b/app/include/logging.h
@@ -1,8 +1,9 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
 
-#include <plog/Log.h>
 #include <string>
+
+#include <plog/Log.h>
 
 namespace Logging {
 

--- a/app/src/cli_app_options_creator.cpp
+++ b/app/src/cli_app_options_creator.cpp
@@ -3,17 +3,18 @@
 #include "app/include/logging.h"
 #include "lib/include/app_options.h"
 
-#include <CLI/CLI.hpp>
 #include <algorithm>
 #include <any>
 #include <filesystem>
-#include <fmt/format.h>
 #include <fstream>
 #include <functional>
 #include <iterator>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+
+#include <CLI/CLI.hpp>
+#include <fmt/format.h>
 
 using namespace std;
 using fmt::format;

--- a/app/src/color.cpp
+++ b/app/src/color.cpp
@@ -1,9 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "app/include/color.h"
 
-#include <fmt/format.h>
-#include <plog/Log.h>
-
 #include <algorithm>
 #include <array>
 #include <cstdio>
@@ -12,6 +9,9 @@
 #include <optional>
 #include <ostream>
 #include <regex>
+
+#include <fmt/format.h>
+#include <plog/Log.h>
 
 constexpr const char *StyleReset = "StyleReset";
 constexpr const char *StyleBold = "StyleBold";

--- a/app/src/logging.cpp
+++ b/app/src/logging.cpp
@@ -1,20 +1,20 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "app/include/logging.h"
 
+#include <cassert>
+#include <cstddef>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <utility>
+
+#include <fmt/format.h>
 #include <plog/Appenders/ColorConsoleAppender.h>
 #include <plog/Appenders/RollingFileAppender.h>
 #include <plog/Formatters/TxtFormatter.h>
 #include <plog/Init.h>
 #include <plog/Log.h>
-
-#include <cassert>
-#include <cstddef>
-#include <filesystem>
-#include <fmt/format.h>
-#include <fstream>
-#include <iostream>
-#include <string>
-#include <utility>
 
 using fmt::format;
 using namespace std;

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -1,17 +1,17 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
-#include "view/include/computer_information_provider.h"
-#include "view/include/computer_information_provider_factory.h"
-
 #include "app/include/cli_app_options_creator.h"
 #include "app/include/color.h"
 #include "app/include/logging.h"
 #include "app/include/main.h"
+#include "view/include/computer_information_provider.h"
+#include "view/include/computer_information_provider_factory.h"
+
+#include <cstdlib>
+#include <iostream>
 
 #include <boost/algorithm/string.hpp>
-#include <cstdlib>
 #include <fmt/color.h>
 #include <fmt/format.h>
-#include <iostream>
 
 using fmt::format;
 using namespace std;

--- a/common/include/human_size.h
+++ b/common/include/human_size.h
@@ -1,6 +1,7 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
 #include <array>
+
 #include <fmt/format.h>
 
 namespace mmotd::algorithm::string {

--- a/common/src/chrono_io.cpp
+++ b/common/src/chrono_io.cpp
@@ -1,6 +1,7 @@
 #include "common/include/chrono_io.h"
 
 #include <chrono>
+
 #include <fmt/chrono.h>
 
 using namespace std;

--- a/common/src/platform_error.cpp
+++ b/common/src/platform_error.cpp
@@ -1,9 +1,10 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/platform_error.h"
 
+#include <vector>
+
 #include <fmt/format.h>
 #include <plog/Log.h>
-#include <vector>
 
 using namespace std;
 using fmt::format;

--- a/lib/include/app_options.h
+++ b/lib/include/app_options.h
@@ -1,12 +1,13 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
 
-#include <boost/logic/tribool.hpp>
 #include <cstdint>
 #include <iosfwd>
 #include <optional>
 #include <string>
 #include <vector>
+
+#include <boost/logic/tribool.hpp>
 
 class AppOptionsCreator;
 

--- a/lib/include/network.h
+++ b/lib/include/network.h
@@ -3,11 +3,12 @@
 #include "lib/include/information_provider.h"
 
 #include <array>
-#include <boost/asio/ip/address.hpp>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include <boost/asio/ip/address.hpp>
 
 namespace mmotd {
 

--- a/lib/src/app_options.cpp
+++ b/lib/src/app_options.cpp
@@ -2,9 +2,10 @@
 #include "lib/include/app_options.h"
 #include "lib/include/app_options_creator.h"
 
-#include <fmt/format.h>
 #include <iostream>
 #include <string_view>
+
+#include <fmt/format.h>
 
 using fmt::format;
 using namespace std;

--- a/lib/src/computer_information.cpp
+++ b/lib/src/computer_information.cpp
@@ -4,8 +4,9 @@
 #include "lib/include/information_provider.h"
 
 #include <algorithm>
-#include <fmt/format.h>
 #include <iterator>
+
+#include <fmt/format.h>
 #include <plog/Log.h>
 
 using namespace std;

--- a/lib/src/external_network.cpp
+++ b/lib/src/external_network.cpp
@@ -3,13 +3,14 @@
 #include "lib/include/external_network.h"
 #include "lib/include/http_request.h"
 
+#include <sstream>
+#include <tuple>
+
 #include <boost/asio/ip/address.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <fmt/format.h>
 #include <plog/Log.h>
-#include <sstream>
-#include <tuple>
 
 using boost::asio::ip::make_address;
 using fmt::format;

--- a/lib/src/file_system.cpp
+++ b/lib/src/file_system.cpp
@@ -4,6 +4,7 @@
 #include "lib/include/file_system.h"
 
 #include <filesystem>
+
 #include <fmt/format.h>
 #include <plog/Log.h>
 

--- a/lib/src/http_request.cpp
+++ b/lib/src/http_request.cpp
@@ -1,6 +1,9 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "lib/include/http_request.h"
 
+#include <cstdlib>
+#include <string>
+
 #include <boost/asio/connect.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/beast/core.hpp>
@@ -9,10 +12,8 @@
 #include <boost/beast/version.hpp>
 #include <boost/exception/all.hpp>
 #include <boost/system/error_code.hpp>
-#include <cstdlib>
 #include <fmt/format.h>
 #include <plog/Log.h>
-#include <string>
 
 namespace beast = boost::beast; // from <boost/beast.hpp>
 namespace http = beast::http;   // from <boost/beast/http.hpp>

--- a/lib/src/http_secure_request.cpp
+++ b/lib/src/http_secure_request.cpp
@@ -11,7 +11,6 @@
 #include <boost/beast/http/write.hpp>
 #include <boost/certify/extensions.hpp>
 #include <boost/certify/https_verification.hpp>
-
 #include <fmt/format.h>
 #include <plog/Log.h>
 

--- a/lib/src/lastlog.cpp
+++ b/lib/src/lastlog.cpp
@@ -8,12 +8,14 @@
 #include <cassert>
 #include <chrono>
 #include <ctime>
+#include <string>
+
 #include <fmt/format.h>
 #include <plog/Log.h>
-#include <pwd.h>
 #include <scope_guard.hpp>
+
+#include <pwd.h>
 #include <string.h>
-#include <string>
 #include <unistd.h>
 #include <utmpx.h>
 

--- a/lib/src/load_average.cpp
+++ b/lib/src/load_average.cpp
@@ -3,21 +3,11 @@
 #include "lib/include/computer_information.h"
 #include "lib/include/load_average.h"
 
-// #include <mach/host_info.h>
-// #include <mach/mach.h>
-// #include <mach/mach_error.h>
-// #include <mach/mach_host.h>
-// #include <mach/mach_init.h>
-// #include <mach/mach_types.h>
-// #include <mach/processor_info.h>
-// #include <mach/vm_map.h>
-// #include <mach/vm_statistics.h>
-#include <sys/sysctl.h>
-// #include <sys/types.h>
-#include <time.h>
-
 #include <fmt/format.h>
 #include <plog/Log.h>
+
+#include <sys/sysctl.h>
+#include <time.h>
 
 using fmt::format;
 using namespace std;
@@ -59,67 +49,6 @@ optional<int32_t> GetCpuCount() {
     }
 }
 
-#if 0
-void LoadAverageSleep(time_t seconds) {
-    struct timespec request_time_spec = {seconds, 0};
-    struct timespec interrupted_time_spec = {0, 0};
-    if (nanosleep(&request_time_spec, &interrupted_time_spec) == -1) {
-        PLOG_ERROR << format("nanosleep was interrupted and returned {}s, {}ns early, error: {}",
-                             interrupted_time_spec.tv_sec,
-                             interrupted_time_spec.tv_nsec,
-                             mmotd::platform::error::to_string(errno));
-    }
-}
-
-optional<host_cpu_load_info_data_t> GetCpuLoadInfoData() {
-    mach_msg_type_number_t count = HOST_CPU_LOAD_INFO_COUNT;
-    mach_port_t mach_port = mach_host_self();
-    host_cpu_load_info_data_t cpu_load_info_data = {0};
-    kern_return_t error =
-        host_statistics(mach_port, HOST_CPU_LOAD_INFO, reinterpret_cast<host_info_t>(&cpu_load_info_data), &count);
-    if (error != KERN_SUCCESS) {
-        PLOG_ERROR << format("host_statistics returned error {}", error);
-        return nullopt;
-    }
-
-    return make_optional(cpu_load_info_data);
-}
-
-optional<double> GetCpuUsage(time_t delay_seconds) {
-    auto cpu_load_info_data_wrapper1 = GetCpuLoadInfoData();
-    if (!cpu_load_info_data_wrapper1) {
-        return nullopt;
-    }
-    LoadAverageSleep(delay_seconds);
-    auto cpu_load_info_data_wrapper2 = GetCpuLoadInfoData();
-    if (!cpu_load_info_data_wrapper2) {
-        return nullopt;
-    }
-
-    auto cpu_load_info_data1 = cpu_load_info_data_wrapper1.value();
-    auto cpu_load_info_data2 = cpu_load_info_data_wrapper2.value();
-
-    auto current_user = cpu_load_info_data1.cpu_ticks[CPU_STATE_USER];
-    auto current_system = cpu_load_info_data1.cpu_ticks[CPU_STATE_SYSTEM];
-    auto current_nice = cpu_load_info_data1.cpu_ticks[CPU_STATE_NICE];
-    auto current_idle = cpu_load_info_data1.cpu_ticks[CPU_STATE_IDLE];
-
-    auto next_user = cpu_load_info_data2.cpu_ticks[CPU_STATE_USER];
-    auto next_system = cpu_load_info_data2.cpu_ticks[CPU_STATE_SYSTEM];
-    auto next_nice = cpu_load_info_data2.cpu_ticks[CPU_STATE_NICE];
-    auto next_idle = cpu_load_info_data2.cpu_ticks[CPU_STATE_IDLE];
-
-    auto diff_user = next_user - current_user;
-    auto diff_system = next_system - current_system;
-    auto diff_nice = next_nice - current_nice;
-    auto diff_idle = next_idle - current_idle;
-
-    auto cpu_usage = static_cast<double>(diff_user + diff_system + diff_nice) /
-                     static_cast<double>(diff_user + diff_system + diff_nice + diff_idle) * 100.0;
-    return make_optional(cpu_usage);
-}
-#endif
-
 optional<double> GetSystemLoadAverage() {
     auto load = loadavg{};
     auto load_size = sizeof(load);
@@ -138,11 +67,6 @@ optional<double> GetSystemLoadAverage() {
 } // namespace detail
 
 bool LoadAverage::GetLoadAverage() {
-    // auto cpu_usage_wrapper = detail::GetCpuUsage(1);
-    // if (!cpu_usage_wrapper) {
-    //     return false;
-    // }
-    // auto cpu_usage = cpu_usage_wrapper.value();
     auto system_load_average_wrapper = detail::GetSystemLoadAverage();
     if (!system_load_average_wrapper) {
         return false;
@@ -153,8 +77,6 @@ bool LoadAverage::GetLoadAverage() {
         return false;
     }
     auto cpu_count = cpu_count_wrapper.value();
-    //auto load_percent = static_cast<double>(cpu_count) / load_average;
-    // details_.push_back(make_tuple("load average", format("cpu usage: {:.02f}%", cpu_usage)));
     details_.push_back(make_tuple("load average", format("system load average: {:.02f}%", system_load_average)));
     details_.push_back(make_tuple("processor count", to_string(cpu_count)));
     return true;

--- a/lib/src/memory.cpp
+++ b/lib/src/memory.cpp
@@ -4,14 +4,14 @@
 #include "lib/include/computer_information.h"
 #include "lib/include/memory.h"
 
+#include <fmt/format.h>
+#include <plog/Log.h>
+#include <scope_guard.hpp>
+
 #include <mach/mach.h>
 #include <mach/mach_types.h>
 #include <mach/vm_statistics.h>
 #include <sys/sysctl.h>
-
-#include <fmt/format.h>
-#include <plog/Log.h>
-#include <scope_guard.hpp>
 
 using fmt::format;
 using namespace std;

--- a/lib/src/network.cpp
+++ b/lib/src/network.cpp
@@ -3,6 +3,19 @@
 #include "lib/include/computer_information.h"
 #include "lib/include/network.h"
 
+#include <algorithm>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/numeric/conversion/cast.hpp>
+#include <fmt/format.h>
+#include <plog/Log.h>
+#include <scope_guard.hpp>
+
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <net/if_dl.h>
@@ -12,18 +25,6 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
-
-#include <algorithm>
-#include <boost/algorithm/string.hpp>
-#include <boost/numeric/conversion/cast.hpp>
-#include <fmt/format.h>
-#include <iostream>
-#include <optional>
-#include <plog/Log.h>
-#include <scope_guard.hpp>
-#include <stdexcept>
-#include <string>
-#include <vector>
 
 using boost::asio::ip::make_address;
 using fmt::format;

--- a/lib/src/posix_system_information.cpp
+++ b/lib/src/posix_system_information.cpp
@@ -2,13 +2,15 @@
 #include "lib/include/computer_information.h"
 #include "lib/include/posix_system_information.h"
 
-#include <boost/algorithm/string.hpp>
-#include <fmt/format.h>
 #include <iostream>
 #include <optional>
-#include <plog/Log.h>
 #include <sstream>
 #include <stdexcept>
+
+#include <boost/algorithm/string.hpp>
+#include <fmt/format.h>
+#include <plog/Log.h>
+
 #include <sys/utsname.h>
 
 using namespace fmt;

--- a/lib/src/swap.cpp
+++ b/lib/src/swap.cpp
@@ -4,12 +4,13 @@
 #include "lib/include/computer_information.h"
 #include "lib/include/swap.h"
 
-#include <sys/sysctl.h>
+#include <unordered_map>
 
 #include <fmt/format.h>
 #include <plog/Log.h>
 #include <scope_guard.hpp>
-#include <unordered_map>
+
+#include <sys/sysctl.h>
 
 using fmt::format;
 using namespace std;

--- a/lib/src/users_logged_in.cpp
+++ b/lib/src/users_logged_in.cpp
@@ -2,10 +2,11 @@
 #include "lib/include/computer_information.h"
 #include "lib/include/users_logged_in.h"
 
+#include <unordered_map>
+
 #include <fmt/format.h>
 #include <plog/Log.h>
 #include <scope_guard.hpp>
-#include <unordered_map>
 
 #include <utmpx.h>
 

--- a/view/src/active_network_interfaces.cpp
+++ b/view/src/active_network_interfaces.cpp
@@ -3,12 +3,13 @@
 #include "view/include/active_network_interfaces.h"
 #include "view/include/computer_information_provider_factory.h"
 
-#include <boost/algorithm/string.hpp>
-#include <fmt/format.h>
 #include <iterator>
-#include <plog/Log.h>
 #include <unordered_map>
 #include <vector>
+
+#include <boost/algorithm/string.hpp>
+#include <fmt/format.h>
+#include <plog/Log.h>
 
 using namespace std;
 using fmt::format;

--- a/view/src/last_login.cpp
+++ b/view/src/last_login.cpp
@@ -4,9 +4,10 @@
 #include "view/include/last_login.h"
 
 #include <array>
+#include <string>
+
 #include <fmt/format.h>
 #include <plog/Log.h>
-#include <string>
 
 using fmt::format;
 using namespace std;


### PR DESCRIPTION
Finally getting around to making the `sort includes` feature of clang-format to work correctly for the project.