### PR TITLE
Add correct time zone support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -79,6 +79,9 @@ IncludeCategories:
   # Boost headers
   - Regex:    '^[<"]boost/'
     Priority: 30
+  # Date headers
+  - Regex:    '^[<"]date/'
+    Priority: 30
   # Catch2 unit test headers
   - Regex:    '^[<"]catch2/'
     Priority: 30

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,47 +1,60 @@
 ---
-Checks:                'abseil-*,android-*,boost-*,bugprone-*,cert-*,clang-analyzer-*,cppcoreguidelines-*,darwin-*,fuchsia-*,google-*,hicpp-*,linuxkernel-*,llvm-*,llvmlibc-*,misc-*,modernize-*,mpi-*,objc-*,openmp-*,performance-*,portability-*,readability-*,zircon-*'
-WarningsAsErrors:      'abseil-*,android-*,boost-*,bugprone-*,cert-*,clang-analyzer-*,cppcoreguidelines-*,darwin-*,fuchsia-*,google-*,hicpp-*,linuxkernel-*,llvm-*,llvmlibc-*,misc-*,modernize-*,mpi-*,objc-*,openmp-*,performance-*,portability-*,readability-*,zircon-*'
-HeaderFilterRegex:     ''
-AnalyzeTemporaryDtors: false
-FormatStyle:           file
-User:                  jasoni
-CheckOptions:
-  - key:             cert-dcl16-c.NewSuffixes
-    value:           'L;LL;LU;LLU'
-  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
-    value:           '0'
-  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
-    value:           '0'
-  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
-    value:           '1'
-  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
-    value:           '1'
-  - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '1'
-  - key:             google-readability-function-size.StatementThreshold
-    value:           '800'
-  - key:             google-readability-namespace-comments.ShortNamespaceLines
-    value:           '10'
-  - key:             google-readability-namespace-comments.SpacesBeforeComments
-    value:           '2'
-  - key:             llvm-else-after-return.WarnOnConditionVariables
-    value:           '0'
-  - key:             llvm-else-after-return.WarnOnUnfixable
-    value:           '0'
-  - key:             llvm-qualified-auto.AddConstToQualified
-    value:           '0'
-  - key:             modernize-loop-convert.MaxCopySize
-    value:           '16'
-  - key:             modernize-loop-convert.MinConfidence
-    value:           reasonable
-  - key:             modernize-loop-convert.NamingStyle
-    value:           CamelCase
-  - key:             modernize-pass-by-value.IncludeStyle
-    value:           llvm
-  - key:             modernize-replace-auto-ptr.IncludeStyle
-    value:           llvm
-  - key:             modernize-use-nullptr.NullMacros
-    value:           'NULL'
+# Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming'
+# FormatStyle: file
+# CheckOptions:
+#   - key:             readability-identifier-naming.ClassCase
+#     value:           CamelCase
+#   - key:             readability-identifier-naming.EnumCase
+#     value:           CamelCase
+#   - key:             readability-identifier-naming.FunctionCase
+#     value:           camelBack
+#   - key:             readability-identifier-naming.MemberCase
+#     value:           CamelCase
+#   - key:             readability-identifier-naming.ParameterCase
+#     value:           CamelCase
+#   - key:             readability-identifier-naming.UnionCase
+#     value:           CamelCase
+#   - key:             readability-identifier-naming.VariableCase
+#     value:           CamelCase
+#   - key:             readability-identifier-naming.IgnoreMainLikeFunctions
+#     value:           1
+# Checks: 'abseil-*,android-*,boost-*,bugprone-*,cert-*,clang-analyzer-*,cppcoreguidelines-*,darwin-*,fuchsia-*,google-*,hicpp-*,linuxkernel-*,llvm-*,llvmlibc-*,misc-*,modernize-*,mpi-*,objc-*,openmp-*,performance-*,portability-*,readability-*,zircon-*'
+# HeaderFilterRegex:     ''
+# CheckOptions:
+#   - key:             cert-dcl16-c.NewSuffixes
+#     value:           'L;LL;LU;LLU'
+#   - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+#     value:           '0'
+#   - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+#     value:           '0'
+#   - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+#     value:           '1'
+#   - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+#     value:           '1'
+#   - key:             google-readability-braces-around-statements.ShortStatementLines
+#     value:           '1'
+#   - key:             google-readability-function-size.StatementThreshold
+#     value:           '800'
+#   - key:             google-readability-namespace-comments.ShortNamespaceLines
+#     value:           '10'
+#   - key:             google-readability-namespace-comments.SpacesBeforeComments
+#     value:           '2'
+#   - key:             llvm-else-after-return.WarnOnConditionVariables
+#     value:           '0'
+#   - key:             llvm-else-after-return.WarnOnUnfixable
+#     value:           '0'
+#   - key:             llvm-qualified-auto.AddConstToQualified
+#     value:           '0'
+#   - key:             modernize-loop-convert.MaxCopySize
+#     value:           '16'
+#   - key:             modernize-loop-convert.MinConfidence
+#     value:           reasonable
+#   - key:             modernize-loop-convert.NamingStyle
+#     value:           CamelCase
+#   - key:             modernize-pass-by-value.IncludeStyle
+#     value:           llvm
+#   - key:             modernize-replace-auto-ptr.IncludeStyle
+#     value:           llvm
+#   - key:             modernize-use-nullptr.NullMacros
+#     value:           'NULL'
 ...
-
-

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,8 @@
+---
+Index:
+  Background: Skip     # Disable slow background indexing of these files.
+Diagnostics:
+  ClangTidy:
+    # Add: modernize*
+    Remove: '*,else-after-return'
+...

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/*.log
 .cache/
 .clangd/
 .vsbuild/

--- a/cmake/find_dependencies.cmake
+++ b/cmake/find_dependencies.cmake
@@ -31,6 +31,17 @@ if (APPLE)
     find_library(FWSecurity NAMES Security REQUIRED)
 endif ()
 
+# Component: date.  Howard Hinnant's Date library (author of the std::chrono library among others)
+option (BUILD_TZ_LIB "build/install of TZ library" ON)
+FetchContent_Declare(date
+    GIT_REPOSITORY   https://github.com/HowardHinnant/date.git
+    GIT_TAG          v3.0.0
+    GIT_PROGRESS     TRUE
+)
+set(MESSAGE_QUIET ON)
+FetchContent_MakeAvailable(date)
+unset(MESSAGE_QUIET)
+
 # Component: Backward.  Stack trace library
 FetchContent_Declare(Backward
     GIT_REPOSITORY   https://github.com/bombela/backward-cpp.git

--- a/cmake/target_common.cmake
+++ b/cmake/target_common.cmake
@@ -181,6 +181,7 @@ macro (setup_target_properties MMOTD_TARTET_NAME PROJECT_ROOT_INCLUDE_PATH)
         PRIVATE ${fmt_SOURCE_DIR}/include
         PRIVATE ${random_SOURCE_DIR}/include
         PRIVATE ${json_SOURCE_DIR}/include
+        PRIVATE ${date_SOURCE_DIR}/include
         PRIVATE ${scope_guard_SOURCE_DIR}
         PRIVATE ${OPENSSL_INCLUDE_DIR}
         )
@@ -209,6 +210,7 @@ macro (setup_target_properties MMOTD_TARTET_NAME PROJECT_ROOT_INCLUDE_PATH)
             PRIVATE fort
             PRIVATE nlohmann_json::nlohmann_json
             PRIVATE fmt::fmt
+            PRIVATE date-tz
             PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang>:-lc++>
             PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang>:-lc++abi>
             PRIVATE $<$<PLATFORM_ID:Darwin>:${FWCoreFoundation}>

--- a/common/include/chrono_io.h
+++ b/common/include/chrono_io.h
@@ -1,213 +1,70 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
+#include "common/assertion/include/assertion.h"
+
 #include <chrono>
 #include <cstdlib>
 #include <ctime>
 #include <optional>
+#include <sstream>
 #include <string>
 
-#include <fmt/chrono.h>
+#include <date/date.h>
+#include <date/tz.h>
+#include <fmt/ostream.h>
 #include <plog/Log.h>
-
-#include <time.h>
 
 namespace mmotd::chrono::io {
 
-enum class FromStringFormat {
-    TimeFormat, // 18:47:01 or \d{2}:\d{2}\d{2}
-};
-
 namespace detail {
 
-class DateTimeFields {
-public:
-    enum Field : uint32_t {
-        NONE = 1 << 0,
-        SECONDS = 1 << 1,
-        MINUTES = 1 << 2,
-        HOURS = 1 << 3,
-        MONTH_DAY = 1 << 4,
-        MONTH = 1 << 5,
-        YEAR = 1 << 6,
-        WEEK_DAY = 1 << 7,
-        YEAR_DAY = 1 << 8,
-        IS_DAYLIGHT_SAVINGS = 1 << 9,
-        OFFSET_FROM_GMT = 1 << 10,
-        TIMEZONE_ABBR = 1 << 11
-    };
-
-    friend constexpr Field operator|(Field a, Field b) noexcept {
-        return static_cast<Field>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+inline std::string to_string(date::time_of_day<std::chrono::seconds> tod, std::string chrono_format) {
+    auto fields = date::fields{tod};
+    auto result = date::format(chrono_format, fields);
+    if (auto am_index = result.rfind("AM"); am_index != std::string::npos) {
+        result[am_index] = 'a';
+        result[am_index + 1] = 'm';
     }
-    friend constexpr Field operator&(Field a, Field b) noexcept {
-        return static_cast<Field>(static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
+    if (auto pm_index = result.rfind("PM"); pm_index != std::string::npos) {
+        result[pm_index] = 'p';
+        result[pm_index + 1] = 'm';
     }
-
-    DateTimeFields() = default;
-    DateTimeFields(const std::tm &date_time_tm, DateTimeFields::Field fields);
-
-    bool IsAnyFieldSet() const noexcept { return fields_ != Field::NONE; }
-    bool IsFieldSet(Field field_mask) const noexcept { return (fields_ & field_mask) == field_mask; }
-
-    template<FromStringFormat format>
-    static std::optional<DateTimeFields> from_string(std::string) {
-        return std::nullopt;
-    }
-
-    void Import(const std::tm &tm_time) noexcept;
-    std::tm Export(const std::tm &tm_time) noexcept;
-
-private:
-    std::tm date_time_tm_{};
-    Field fields_ = Field::NONE;
-};
-
-inline DateTimeFields::DateTimeFields(const std::tm &date_time_tm, DateTimeFields::Field fields) {
-    fields_ = fields;
-    Import(date_time_tm);
+    return result;
 }
 
-inline void DateTimeFields::Import(const std::tm &tm_time) noexcept {
-    if (IsFieldSet(DateTimeFields::Field::SECONDS)) {
-        date_time_tm_.tm_sec = tm_time.tm_sec;
+template<class Clock, class Duration>
+inline std::string to_string(std::chrono::time_point<Clock, Duration> time_point, std::string chrono_format) {
+    auto time_point_zoned = date::make_zoned(date::current_zone(), time_point);
+    auto result = date::format(chrono_format, time_point_zoned);
+    if (auto am_index = result.rfind("AM"); am_index != std::string::npos) {
+        result[am_index] = 'a';
+        result[am_index + 1] = 'm';
     }
-    if (IsFieldSet(DateTimeFields::Field::MINUTES)) {
-        date_time_tm_.tm_min = tm_time.tm_min;
+    if (auto pm_index = result.rfind("PM"); pm_index != std::string::npos) {
+        result[pm_index] = 'p';
+        result[pm_index + 1] = 'm';
     }
-    if (IsFieldSet(DateTimeFields::Field::HOURS)) {
-        date_time_tm_.tm_hour = tm_time.tm_hour;
-    }
-    if (IsFieldSet(DateTimeFields::Field::MONTH_DAY)) {
-        date_time_tm_.tm_mday = tm_time.tm_mday;
-    }
-    if (IsFieldSet(DateTimeFields::Field::MONTH)) {
-        date_time_tm_.tm_mon = tm_time.tm_mon;
-    }
-    if (IsFieldSet(DateTimeFields::Field::YEAR)) {
-        date_time_tm_.tm_year = tm_time.tm_year;
-    }
-    if (IsFieldSet(DateTimeFields::Field::WEEK_DAY)) {
-        date_time_tm_.tm_wday = tm_time.tm_wday;
-    }
-    if (IsFieldSet(DateTimeFields::Field::YEAR_DAY)) {
-        date_time_tm_.tm_yday = tm_time.tm_yday;
-    }
-    if (IsFieldSet(DateTimeFields::Field::IS_DAYLIGHT_SAVINGS)) {
-        date_time_tm_.tm_isdst = tm_time.tm_isdst;
-    }
-    if (IsFieldSet(DateTimeFields::Field::OFFSET_FROM_GMT)) {
-        date_time_tm_.tm_gmtoff = tm_time.tm_gmtoff;
-    }
-    if (IsFieldSet(DateTimeFields::Field::TIMEZONE_ABBR)) {
-        date_time_tm_.tm_zone = tm_time.tm_zone;
-    }
+    return result;
 }
 
-inline std::tm DateTimeFields::Export(const std::tm &tm_time) noexcept {
-    auto new_tm{tm_time};
-    if (IsFieldSet(DateTimeFields::Field::SECONDS)) {
-        new_tm.tm_sec = date_time_tm_.tm_sec;
+inline auto from_string(std::string input, std::string chrono_format) {
+    using namespace std::chrono;
+    auto seconds_since_midnight = std::chrono::seconds{};
+    std::istringstream stream{input};
+    stream >> date::parse(chrono_format, seconds_since_midnight);
+    auto tod = date::make_time(seconds_since_midnight);
+    PLOG_VERBOSE << fmt::format("parsed time: {}, using format: {}, from string: '{}'", tod, chrono_format, input);
+    if (stream.fail()) {
+        PLOG_ERROR << fmt::format("failed to parse string: '{}', using format: {}", input, chrono_format);
     }
-    if (IsFieldSet(DateTimeFields::Field::MINUTES)) {
-        new_tm.tm_min = date_time_tm_.tm_min;
-    }
-    if (IsFieldSet(DateTimeFields::Field::HOURS)) {
-        new_tm.tm_hour = date_time_tm_.tm_hour;
-    }
-    if (IsFieldSet(DateTimeFields::Field::MONTH_DAY)) {
-        new_tm.tm_mday = date_time_tm_.tm_mday;
-    }
-    if (IsFieldSet(DateTimeFields::Field::MONTH)) {
-        new_tm.tm_mon = date_time_tm_.tm_mon;
-    }
-    if (IsFieldSet(DateTimeFields::Field::YEAR)) {
-        new_tm.tm_year = date_time_tm_.tm_year;
-    }
-    if (IsFieldSet(DateTimeFields::Field::WEEK_DAY)) {
-        new_tm.tm_wday = date_time_tm_.tm_wday;
-    }
-    if (IsFieldSet(DateTimeFields::Field::YEAR_DAY)) {
-        new_tm.tm_yday = date_time_tm_.tm_yday;
-    }
-    if (IsFieldSet(DateTimeFields::Field::IS_DAYLIGHT_SAVINGS)) {
-        new_tm.tm_isdst = date_time_tm_.tm_isdst;
-    }
-    if (IsFieldSet(DateTimeFields::Field::OFFSET_FROM_GMT)) {
-        new_tm.tm_gmtoff = date_time_tm_.tm_gmtoff;
-    }
-    if (IsFieldSet(DateTimeFields::Field::TIMEZONE_ABBR)) {
-        new_tm.tm_zone = const_cast<char *>(date_time_tm_.tm_zone);
-    }
-    return new_tm;
+    return !stream.fail() ? std::make_optional(tod) : std::nullopt;
 }
 
-template<>
-inline std::optional<DateTimeFields> DateTimeFields::from_string<FromStringFormat::TimeFormat>(std::string input_str) {
-    auto date_time_tm = std::tm{};
-    if (strptime(input_str.c_str(), "%H:%M:%S", &date_time_tm) == nullptr) {
-        PLOG_ERROR << fmt::format("error while converting string '{}' to a std::tm time struct", input_str);
-        return std::nullopt;
-    }
-    auto fields = DateTimeFields::Field::SECONDS | DateTimeFields::Field::MINUTES | DateTimeFields::Field::HOURS;
-    return std::make_optional(DateTimeFields(date_time_tm, fields));
-}
-
-inline std::optional<DateTimeFields> from_string_impl(std::string input_str, FromStringFormat fmt) {
-    if (fmt == FromStringFormat::TimeFormat) {
-        return DateTimeFields::from_string<FromStringFormat::TimeFormat>(input_str);
-    }
-    return std::nullopt;
-}
-
-inline std::string to_string(std::chrono::system_clock::time_point time_point, std::string chrono_format) {
-    static auto initialized_time_zone = false;
-    if (!initialized_time_zone) {
-        initialized_time_zone = true;
-        setenv("TZ", "/usr/share/zoneinfo/MST", 1); // fix_jasoni: POSIX-specific
-        tzset();
-    }
-    auto local_time = fmt::localtime(std::chrono::system_clock::to_time_t(time_point));
-    PLOG_VERBOSE << fmt::format("setting tm_isdst: {}",
-                                (daylight == 0 ? "(0) false" : (daylight == 1 ? "(1) true" : "-1 undetermined")));
-    local_time.tm_isdst = daylight;
-    auto time_point_str = fmt::format(chrono_format, local_time);
-    if (auto am_index = time_point_str.rfind("AM"); am_index != std::string::npos) {
-        time_point_str[am_index] = 'a';
-        time_point_str[am_index + 1] = 'm';
-    }
-    if (auto pm_index = time_point_str.rfind("PM"); pm_index != std::string::npos) {
-        time_point_str[pm_index] = 'p';
-        time_point_str[pm_index + 1] = 'm';
-    }
-    return time_point_str;
-}
-
-inline std::optional<std::chrono::system_clock::time_point> from_string(std::string input_str,
-                                                                        FromStringFormat format_type) {
-    using sys_clock = std::chrono::system_clock;
-    auto date_time_fields_holder = from_string_impl(input_str, format_type);
-    setenv("TZ", "/usr/share/zoneinfo/MST", 1); // fix_jasoni: POSIX-specific
-    if (!date_time_fields_holder) {
-        PLOG_ERROR << fmt::format("error returned when converting {} to std::tm structure", input_str);
-        return std::nullopt;
-    }
-    auto date_time_fields = *date_time_fields_holder;
-    if (!date_time_fields.IsAnyFieldSet()) {
-        PLOG_ERROR << fmt::format("no fields were set after converting {} to std::tm structure", input_str);
-        return std::nullopt;
-    }
-    auto now_tm = fmt::localtime(sys_clock::to_time_t(sys_clock::now()));
-    auto input_tm = date_time_fields.Export(now_tm);
-    auto input_time_since_epoch = std::mktime(&input_tm);
-    return std::make_optional(sys_clock::from_time_t(input_time_since_epoch));
-}
-
-inline int get_current_hour() {
-    using sys_clock = std::chrono::system_clock;
-    setenv("TZ", "/usr/share/zoneinfo/MST", 1); // fix_jasoni: POSIX-specific
-    time_t now_time_since_epoch = sys_clock::to_time_t(sys_clock::now());
-    auto now_tm = fmt::localtime(now_time_since_epoch);
-    return now_tm.tm_hour;
+inline auto get_current_hour() {
+    auto now_time_zoned = date::make_zoned(date::current_zone(), std::chrono::system_clock::now());
+    auto tod = date::make_time(now_time_zoned.get_local_time().time_since_epoch());
+    PLOG_VERBOSE << fmt::format("current hour: {}, from current time: {}", tod.hours().count(), tod);
+    return tod.hours().count();
 }
 
 } // namespace detail

--- a/common/results/src/output_table.cpp
+++ b/common/results/src/output_table.cpp
@@ -115,8 +115,14 @@ private:
     void WriteName(const Row &row, size_t line_index);
     void WriteValue(const Row &row, size_t line_index, bool bump_column);
 
-    //using TableType = fort::utf8_table;
+#if defined(__APPLE__)
+    using TableType = fort::utf8_table;
+#elif defined(__linux__)
     using TableType = fort::char_table;
+#else
+    using TableType = fort::char_table;
+#endif
+
     TableType &GetTable() { return table_; }
     const TableType &GetTable() const { return table_; }
     size_t GetColumnCount() const { return column_count_; }

--- a/lib/src/boot_time.cpp
+++ b/lib/src/boot_time.cpp
@@ -33,7 +33,7 @@ bool BootTime::FindInformation() {
     auto boot_time = boot_time_holder ? *boot_time_holder : std::chrono::system_clock::now();
 
     auto info = GetInfoTemplate(InformationId::ID_BOOT_TIME_BOOT_TIME);
-    info.SetValue(chrono::io::to_string(boot_time, "{:%a, %d-%h-%Y %I:%M:%S%p %Z}"));
+    info.SetValue(chrono::io::to_string(boot_time, "%a, %d-%h-%Y %I:%M%p %Z"));
     AddInformation(info);
 
     return true;

--- a/lib/src/lastlog.cpp
+++ b/lib/src/lastlog.cpp
@@ -24,14 +24,14 @@ bool LastLog::FindInformation() {
     AddInformation(last_log);
 
     auto log_in = GetInfoTemplate(InformationId::ID_LAST_LOGIN_LOGIN_TIME);
-    log_in.SetValue(chrono::io::to_string(lastlog_details.log_in, "{:%a, %d-%h-%Y %I:%M:%S%p %Z}"));
+    log_in.SetValue(chrono::io::to_string(lastlog_details.log_in, "%a, %d-%h-%Y %I:%M%p %Z"));
     AddInformation(log_in);
 
     auto log_out = GetInfoTemplate(InformationId::ID_LAST_LOGIN_LOGOUT_TIME);
     if (lastlog_details.log_out == std::chrono::system_clock::time_point{}) {
         log_out.SetValue("still logged in");
     } else {
-        log_out.SetValue(chrono::io::to_string(lastlog_details.log_out, "{:%a, %d-%h-%Y %I:%M:%S%p %Z}"));
+        log_out.SetValue(chrono::io::to_string(lastlog_details.log_out, "%a, %d-%h-%Y %I:%M%p %Z"));
     }
     AddInformation(log_out);
 

--- a/lib/src/platform/darwin/boot_time.cpp
+++ b/lib/src/platform/darwin/boot_time.cpp
@@ -36,7 +36,7 @@ optional<std::chrono::system_clock::time_point> GetBootTime() {
     }
 
     auto boot_time_point = std::chrono::system_clock::from_time_t(result.tv_sec);
-    PLOG_VERBOSE << format("sysctl(KERN_BOOTTIME): {}", to_string(boot_time_point, "{:%d-%h-%Y %I:%M:%S%p %Z}"));
+    PLOG_VERBOSE << format("sysctl(KERN_BOOTTIME): {}", to_string(boot_time_point, "%d-%h-%Y %I:%M:%S%p %Z"));
     return make_optional(boot_time_point);
 }
 

--- a/lib/src/platform/darwin/lastlog.cpp
+++ b/lib/src/platform/darwin/lastlog.cpp
@@ -55,7 +55,7 @@ LastLoginDetails GetLastLogDetails() {
     auto details = LastLoginDetails{summary, log_in_time, std::chrono::system_clock::time_point{}};
 
     PLOG_VERBOSE << format("last login: {}", details.summary);
-    PLOG_VERBOSE << format("last log in: {}", to_string(details.log_in, "{:%d-%h-%Y %I:%M:%S%p %Z}"));
+    PLOG_VERBOSE << format("last log in: {}", to_string(details.log_in, "%d-%h-%Y %I:%M:%S%p %Z"));
     PLOG_VERBOSE << "last log out: still logged in";
 
     return details;

--- a/lib/src/platform/darwin/user_accounting_database.cpp
+++ b/lib/src/platform/darwin/user_accounting_database.cpp
@@ -84,7 +84,7 @@ namespace mmotd::platform::user_account_database {
 
 string DbEntry::to_string() const {
     auto time_point = std::chrono::system_clock::from_time_t(seconds);
-    auto time_str = mmotd::chrono::io::to_string(time_point, "{:%d-%h-%Y %I:%M:%S%p %Z}");
+    auto time_str = mmotd::chrono::io::to_string(time_point, "%d-%h-%Y %I:%M%p %Z");
     return format("user: {}, device: {}, hostname: {}, time: {}, ip: {}, type: {}",
                   user,
                   device_name,

--- a/lib/src/platform/linux/lastlog.cpp
+++ b/lib/src/platform/linux/lastlog.cpp
@@ -56,7 +56,7 @@ LastLoginDetails GetLastLogDetails() {
     auto details = LastLoginDetails{summary, log_in_time, std::chrono::system_clock::time_point{}};
 
     PLOG_VERBOSE << format("last login: {}", details.summary);
-    PLOG_VERBOSE << format("last log in: {}", to_string(details.log_in, "{:%d-%h-%Y %I:%M:%S%p %Z}"));
+    PLOG_VERBOSE << format("last log in: {}", to_string(details.log_in, "%d-%h-%Y %I:%M:%S%p %Z"));
     PLOG_VERBOSE << "last log out: still logged in";
 
     return details;

--- a/lib/src/platform/linux/user_accounting_database.cpp
+++ b/lib/src/platform/linux/user_accounting_database.cpp
@@ -110,7 +110,7 @@ namespace mmotd::platform::user_account_database {
 
 string DbEntry::to_string() const {
     auto time_point = std::chrono::system_clock::from_time_t(seconds);
-    auto time_str = mmotd::chrono::io::to_string(time_point, "{:%d-%h-%Y %I:%M:%S%p %Z}");
+    auto time_str = mmotd::chrono::io::to_string(time_point, "%d-%h-%Y %I:%M%p %Z");
     return format("user: {}, device: {}, hostname: {}, time: {}, ip: {}, type: {}",
                   user,
                   device_name,

--- a/lib/src/platform/windows/boot_time.cpp
+++ b/lib/src/platform/windows/boot_time.cpp
@@ -34,7 +34,7 @@ optional<string> GetBootTime() {
     //auto boot_time_point = std::chrono::system_clock::from_time_t(result.tv_sec);
     // Fri, 04-Dec-2020 07:49:36am MST
     // 04-Dec-2020 09:06:02AM MST
-    //return make_optional(mmotd::chrono::io::to_string(boot_time_point, "{:%a, %d-%h-%Y %I:%M:%S%p %Z}"));
+    //return make_optional(mmotd::chrono::io::to_string(boot_time_point, "%a, %d-%h-%Y %I:%M%p %Z"));
     return nullopt;
 }
 

--- a/lib/src/weather_info.cpp
+++ b/lib/src/weather_info.cpp
@@ -57,6 +57,20 @@ bool WeatherInfo::FindInformation() {
     return true;
 }
 
+pair<string, string> ParseSunriseSunset(string sunrise_str, string sunset_str) {
+    auto sunrise_holder = mmotd::chrono::io::from_string(sunrise_str, "%H:%M:%S");
+    auto sunrise_result = string{};
+    if (sunrise_holder) {
+        sunrise_result = mmotd::chrono::io::to_string(*sunrise_holder, "%I:%M:%S%p");
+    }
+    auto sunset_holder = mmotd::chrono::io::from_string(sunset_str, "%H:%M:%S");
+    auto sunset_result = string{};
+    if (sunset_holder) {
+        sunset_result = mmotd::chrono::io::to_string(*sunset_holder, "%I:%M:%S%p");
+    }
+    return {sunrise_result, sunset_result};
+}
+
 tuple<string, string, string, string> WeatherInfo::GetWeatherInfo() {
     using boost::trim_copy, boost::replace_all_copy;
     using namespace mmotd::chrono::io;
@@ -95,17 +109,15 @@ tuple<string, string, string, string> WeatherInfo::GetWeatherInfo() {
     auto sunset_str = weather_str.substr(match.position(2), match.length(2));
     PLOG_INFO << format("sunset: '{}'", sunset_str);
 
-    auto surise_time_point = from_string(sunrise_str, FromStringFormat::TimeFormat);
-    auto sunset_time_point = from_string(sunset_str, FromStringFormat::TimeFormat);
+    auto [sunrise_parsed, sunset_parsed] = ParseSunriseSunset(sunrise_str, sunset_str);
+    sunrise_parsed = empty(sunrise_parsed) ? sunrise_str : sunrise_parsed;
+    sunset_parsed = empty(sunset_parsed) ? sunset_str : sunset_parsed;
 
-    if (surise_time_point) {
-        sunrise_str = to_string(*surise_time_point, "{:%I:%M:%S%p}");
-    }
-    if (sunset_time_point) {
-        sunset_str = to_string(*sunset_time_point, "{:%I:%M:%S%p}");
-    }
-    PLOG_INFO << format("weather: '{}, Sunrise: {}, Sunset: {}'", weather, sunrise_str, sunset_str);
-    return make_tuple(location_str, weather, sunrise_str, sunset_str);
+    PLOG_INFO << format("weather: '{}, Sunrise (parsed): {}, Sunset (parsed): {}'",
+                        weather,
+                        sunrise_parsed,
+                        sunset_parsed);
+    return make_tuple(location_str, weather, sunrise_parsed, sunset_parsed);
 }
 
 } // namespace mmotd::information


### PR DESCRIPTION
Add: Added Howard Hinnant's excellent Date library as an external
dependency.  I believe the entire library was accepted into the C++20
standard so once C++20 is widely supported this can be removed.

Fix: The reason for adding the Date library was that as soon as daylight
saving time kicked in this year all my time output was off by an hour
even after passing it through localtime.  Instead of jumping through
ridiculous hoops to fix the problem the Date library solved the issue
in less than 3 lines of code.  Nothing is better than a well written
API and library.