### PR TITLE
Enforcing compile time check on calls to fmt::format

### DIFF
--- a/apps/mmotd/src/cli_app_options_creator.cpp
+++ b/apps/mmotd/src/cli_app_options_creator.cpp
@@ -28,7 +28,7 @@ public:
         using namespace boost;
         func_ = [](std::string &when) {
             if (!iequals(when, "Always") && !iequals(when, "Auto") && !iequals(when, "Never")) {
-                return format("--color '{}' is invalid (should be 'always', 'auto' or 'never'", when);
+                return format(FMT_STRING("--color '{}' is invalid (should be 'always', 'auto' or 'never'"), when);
             }
             return std::string();
         };
@@ -61,12 +61,12 @@ void CliAppOptionsCreator::Parse(const int argc, char **argv) {
         MMOTD_LOG_INFO(msg);
         cout << msg << endl;
     } catch (const CLI::CallForVersion &version) {
-        const string msg = format("version: {}", mmotd::version::Version::Instance().to_string());
+        const string msg = format(FMT_STRING("version: {}"), mmotd::version::Version::Instance().to_string());
         MMOTD_LOG_INFO(msg);
         cout << msg << endl;
     } catch (const CLI::ParseError &err) {
         if (err.get_exit_code() != 0) {
-            MMOTD_LOG_ERROR(format("error code {}: {}", err.get_exit_code(), err.what()));
+            MMOTD_LOG_ERROR(format(FMT_STRING("error code {}: {}"), err.get_exit_code(), err.what()));
         }
         error_exit_ = true;
     }
@@ -80,7 +80,7 @@ void CliAppOptionsCreator::Parse(const int argc, char **argv) {
         CreateDefaultOutputTemplate(*options_.output_template_path);
         app_finished_ = true;
     }
-    MMOTD_LOG_DEBUG(format("Options:\n{}", options_.to_string()));
+    MMOTD_LOG_DEBUG(format(FMT_STRING("Options:\n{}"), options_.to_string()));
 }
 
 void CliAppOptionsCreator::AddOptionDeclarations(CLI::App &app) {

--- a/apps/mmotd/src/main.cpp
+++ b/apps/mmotd/src/main.cpp
@@ -60,19 +60,19 @@ int main(int argc, char *argv[]) {
         PrintMmotd(*app_options);
     } catch (boost::exception &ex) {
         auto diag = boost::diagnostic_information(ex);
-        auto error_str = format("caught boost::exception in main: {}", diag);
+        auto error_str = format(FMT_STRING("caught boost::exception in main: {}"), diag);
         PLOG_FATAL << error_str;
         std::cerr << error_str << std::endl;
         retval = EXIT_FAILURE;
     } catch (const std::exception &ex) {
         auto diag = boost::diagnostic_information(ex);
-        auto error_str = format("caught std::exception in main: {}", empty(diag) ? ex.what() : data(diag));
+        auto error_str = format(FMT_STRING("caught std::exception in main: {}"), empty(diag) ? ex.what() : data(diag));
         PLOG_FATAL << error_str;
         std::cerr << error_str << std::endl;
         retval = EXIT_FAILURE;
     } catch (...) {
         auto diag = boost::current_exception_diagnostic_information();
-        auto error_str = format("caught unknown exception in main: {}", diag);
+        auto error_str = format(FMT_STRING("caught unknown exception in main: {}"), diag);
         PLOG_FATAL << error_str;
         std::cerr << error_str << std::endl;
         retval = EXIT_FAILURE;

--- a/apps/mmotd_raw/src/main.cpp
+++ b/apps/mmotd_raw/src/main.cpp
@@ -23,7 +23,8 @@ namespace {
 
 string GetInformationNameString(const mmotd::information::Information &information) {
     const auto &name = information.GetName();
-    return !empty(name) ? format(fg(color::lime_green) | emphasis::bold, "{}", name) + ": " : string{};
+    static const auto formatting_color = fg(color::lime_green) | emphasis::bold;
+    return !empty(name) ? format(formatting_color, FMT_STRING("{}"), name) + ": " : string{};
 }
 
 size_t GetInformationNameStringSize(const mmotd::information::Information &information) {
@@ -32,7 +33,8 @@ size_t GetInformationNameStringSize(const mmotd::information::Information &infor
 
 string GetInformationValueString(const mmotd::information::Information &information) {
     const auto &value = information.GetValue();
-    return !empty(value) ? format(fg(color::white) | emphasis::bold, "{}", value) : string{};
+    static const auto formatting_color = fg(color::white) | emphasis::bold;
+    return !empty(value) ? format(formatting_color, FMT_STRING("{}"), value) : string{};
 }
 
 size_t GetColumnWidth(const mmotd::information::Informations &informations) {
@@ -53,12 +55,12 @@ void PrintMmotdRaw() {
         if (!empty(name) && !empty(value)) {
             if (width > 0) {
                 //print("  {:<18} {}\n", name, value);
-                print("  {:<{}} {}\n", name, width, value);
+                print(FMT_STRING("  {:<{}} {}\n"), name, width, value);
             } else {
-                print("  {}{}\n", name, value);
+                print(FMT_STRING("  {}{}\n"), name, value);
             }
         } else if (!empty(value)) {
-            print("  {}\n", value);
+            print(FMT_STRING("  {}\n"), value);
         }
     }
 }
@@ -74,18 +76,18 @@ int main(int argc, char *argv[]) {
         PrintMmotdRaw();
     } catch (boost::exception &ex) {
         auto diag = boost::diagnostic_information(ex);
-        auto error_str = format("caught boost::exception in main: {}", diag);
+        auto error_str = format(FMT_STRING("caught boost::exception in main: {}"), diag);
         PLOG_FATAL << error_str;
         std::cerr << error_str << std::endl;
         retval = EXIT_FAILURE;
     } catch (const std::exception &ex) {
-        auto error_str = format("caught std::exception in main: {}", ex.what());
+        auto error_str = format(FMT_STRING("caught std::exception in main: {}"), ex.what());
         PLOG_FATAL << error_str;
         std::cerr << error_str << std::endl;
         retval = EXIT_FAILURE;
     } catch (...) {
         auto diag = boost::current_exception_diagnostic_information();
-        auto error_str = format("caught unknown exception in main: {}", diag);
+        auto error_str = format(FMT_STRING("caught unknown exception in main: {}"), diag);
         PLOG_FATAL << error_str;
         std::cerr << error_str << std::endl;
         retval = EXIT_FAILURE;

--- a/cmake/find_dependencies.cmake
+++ b/cmake/find_dependencies.cmake
@@ -100,8 +100,6 @@ if (NOT certify_POPULATED)
     target_include_directories(certify INTERFACE ${certify_SOURCE_DIR}/include)
 endif ()
 
-#add_definitions(-DFMT_ENFORCE_COMPILE_STRING=1)
-add_definitions(-DFMT_EXTENDED_COLORS=1)
 # Component: fmt.  The library will be added into C++20 and is already a great substitue for both iostreams and
 #                  printf.  There is support for most all types, re-ordered argument assignment, and builtin
 #                  support for std::date and std::time using the formatting arguments specified with both strftime

--- a/cmake/git_version.cmake
+++ b/cmake/git_version.cmake
@@ -55,6 +55,9 @@ if (NOT MMOTD_NEW_VERSION_H STREQUAL MMOTD_OLD_VERSION_H)
         OUTPUT_VARIABLE MMOTD_GIT_STATUS
         OUTPUT_STRIP_TRAILING_WHITESPACE
         )
+    if (STREQUAL MMOTD_GIT_STATUS "")
+        set(MMOTD_GIT_STATUS " ")
+    endif ()
     string(REPLACE "\n" ";" MMOTD_GIT_STATUS ${MMOTD_GIT_STATUS})
 
     # If cmake/version.cmake is the only modified file

--- a/cmake/target_common.cmake
+++ b/cmake/target_common.cmake
@@ -86,6 +86,9 @@ macro (setup_target_properties MMOTD_TARTET_NAME PROJECT_ROOT_INCLUDE_PATH)
         #  conflicting with the ones in the standard C++ library as they are unintendedly
         #  loaded into the global namespace (doh!).
         PRIVATE $<$<CXX_COMPILER_ID:GNU>:BOOST_BIND_GLOBAL_PLACEHOLDERS=1>
+        # FMT_ENFORCE_COMPILE_STRING requires all format strings to use FMT_STRING which enables
+        #  compile time checking of the format string against the arguments.
+        PRIVATE FMT_ENFORCE_COMPILE_STRING
         # When defined the discovery of system properties will be done serially
         #PRIVATE MMOTD_ASYNC_DISABLED
         )

--- a/common/assertion/src/assertion.cpp
+++ b/common/assertion/src/assertion.cpp
@@ -45,12 +45,13 @@ inline constexpr string_view GetExceptionType(const char *exception_type) noexce
 inline string GetSourceLocation(string_view file_name, string_view function_name, long line) {
     auto source_location = empty(file_name) ? string{} : string(data(file_name));
     if (!empty(function_name)) {
-        source_location += empty(source_location) ? string(data(function_name)) : format(":{}", function_name);
+        source_location +=
+            empty(source_location) ? string(data(function_name)) : format(FMT_STRING(":{}"), function_name);
     }
     if (empty(source_location) && line == 0) {
         return string{};
     } else {
-        return format("{}@{}", source_location, line);
+        return format(FMT_STRING("{}@{}"), source_location, line);
     }
 }
 
@@ -58,11 +59,11 @@ inline string GetExceptionAndMessage(const char *exception_type_str, const char 
     auto exception_type = GetExceptionType(exception_type_str);
     auto msg = GetMessage(msg_str);
     if (!empty(exception_type) && !empty(msg)) {
-        return format("{}: {}", exception_type, msg);
+        return format(FMT_STRING("{}: {}"), exception_type, msg);
     } else if (!empty(exception_type)) {
-        return format("ERROR: {}", exception_type);
+        return format(FMT_STRING("ERROR: {}"), exception_type);
     } else if (!empty(msg)) {
-        return format("ERROR: {}", msg);
+        return format(FMT_STRING("ERROR: {}"), msg);
     } else {
         return string{"<unknown error>"};
     }
@@ -73,14 +74,14 @@ string MakeFailedExpressionAssertionMessage(const char *expr,
                                             const char *file,
                                             long line,
                                             const char *function) {
-    auto assert_msg = format("{} -> Assertion: EXPR FAILED '{}'",
+    auto assert_msg = format(FMT_STRING("{} -> Assertion: EXPR FAILED '{}'"),
                              expr,
                              GetSourceLocation(TrimFileName(file), TrimFunction(function), line));
     if (msg != nullptr) {
-        assert_msg += format(", {}", msg);
+        assert_msg += format(FMT_STRING(", {}"), msg);
     }
     if (auto stacktrace = mmotd::assertion::GetStackTrace(); !empty(stacktrace)) {
-        assert_msg += format("\n{}", stacktrace);
+        assert_msg += format(FMT_STRING("\n{}"), stacktrace);
     }
     return assert_msg;
 }
@@ -90,11 +91,11 @@ string MakeExceptionMessageImpl(const char *exception_type,
                                 const char *file,
                                 long line,
                                 const char *function) {
-    auto exception_msg = format("{} -> {}",
+    auto exception_msg = format(FMT_STRING("{} -> {}"),
                                 GetSourceLocation(TrimFileName(file), TrimFunction(function), line),
                                 GetExceptionAndMessage(exception_type, msg));
     if (auto stacktrace = mmotd::assertion::GetStackTrace(); !empty(stacktrace)) {
-        exception_msg += format("\n{}", stacktrace);
+        exception_msg += format(FMT_STRING("\n{}"), stacktrace);
     }
     return exception_msg;
 }
@@ -102,7 +103,7 @@ string MakeExceptionMessageImpl(const char *exception_type,
 string MakeExceptionMessageImpl(const char *exception_type, const char *msg) {
     auto exception_msg = GetExceptionAndMessage(exception_type, msg);
     if (auto stacktrace = mmotd::assertion::GetStackTrace(); !empty(stacktrace)) {
-        exception_msg += format("\n{}", stacktrace);
+        exception_msg += format(FMT_STRING("\n{}"), stacktrace);
     }
     return exception_msg;
 }

--- a/common/assertion/src/stack_trace.cpp
+++ b/common/assertion/src/stack_trace.cpp
@@ -75,7 +75,7 @@ pair<size_t, size_t> FindParens(string backtrace_detail) {
 string StripFunctionArgs(string backtrace_detail) {
     auto [open_paren, close_paren] = FindParens(backtrace_detail);
     if (open_paren != string::npos && close_paren != string::npos && open_paren + 1 != close_paren) {
-        backtrace_detail = format("{}(...){}",
+        backtrace_detail = format(FMT_STRING("{}(...){}"),
                                   string{begin(backtrace_detail), begin(backtrace_detail) + open_paren},
                                   string{begin(backtrace_detail) + close_paren + 1, end(backtrace_detail)});
     }
@@ -137,7 +137,7 @@ string ReverseStackTraceImpl(vector<string> backtrace_details) {
         for (auto j = begin(details); j != end(details); ++j) {
             auto &sub_detail = *j;
             if (j == begin(details)) {
-                auto index_str = format("#{:<5}", count++);
+                auto index_str = format(FMT_STRING("#{:<5}"), count++);
                 copy(begin(index_str), end(index_str), begin(sub_detail));
             }
             new_backtrace.push_back(StripFunctionArgs(sub_detail));

--- a/common/include/chrono_io.h
+++ b/common/include/chrono_io.h
@@ -53,9 +53,12 @@ inline auto from_string(std::string input, std::string chrono_format) {
     std::istringstream stream{input};
     stream >> date::parse(chrono_format, seconds_since_midnight);
     auto tod = date::make_time(seconds_since_midnight);
-    PLOG_VERBOSE << fmt::format("parsed time: {}, using format: {}, from string: '{}'", tod, chrono_format, input);
+    PLOG_VERBOSE << fmt::format(FMT_STRING("parsed time: {}, using format: {}, from string: '{}'"),
+                                tod,
+                                chrono_format,
+                                input);
     if (stream.fail()) {
-        PLOG_ERROR << fmt::format("failed to parse string: '{}', using format: {}", input, chrono_format);
+        PLOG_ERROR << fmt::format(FMT_STRING("failed to parse string: '{}', using format: {}"), input, chrono_format);
     }
     return !stream.fail() ? std::make_optional(tod) : std::nullopt;
 }
@@ -63,7 +66,7 @@ inline auto from_string(std::string input, std::string chrono_format) {
 inline auto get_current_hour() {
     auto now_time_zoned = date::make_zoned(date::current_zone(), std::chrono::system_clock::now());
     auto tod = date::make_time(now_time_zoned.get_local_time().time_since_epoch());
-    PLOG_VERBOSE << fmt::format("current hour: {}, from current time: {}", tod.hours().count(), tod);
+    PLOG_VERBOSE << fmt::format(FMT_STRING("current hour: {}, from current time: {}"), tod.hours().count(), tod);
     return tod.hours().count();
 }
 

--- a/common/include/human_size.h
+++ b/common/include/human_size.h
@@ -30,7 +30,7 @@ std::string to_human_size(T number) {
         floating_point_bytes = bytes / static_cast<double>(KILO_BYTE);
         bytes /= KILO_BYTE;
     }
-    return fmt::format("{:.02f} {}", floating_point_bytes, suffix);
+    return fmt::format(FMT_STRING("{:.02f} {}"), floating_point_bytes, suffix);
 }
 
 } // namespace mmotd::algorithm::string

--- a/common/include/information.h
+++ b/common/include/information.h
@@ -38,12 +38,12 @@ public:
 
     template<typename S, typename... Args>
     void SetValueFormat(const S &format, Args &&...args) {
-        SetValueImpl(std::string_view(format), fmt::make_args_checked<Args...>(std::string_view(format), args...));
+        SetValueImpl(std::string_view(format), fmt::format_arg_store<fmt::format_context, Args...>(args...));
     }
 
     template<typename... Args>
     void SetValueArgs(Args &&...args) {
-        SetValueImpl(std::data(format_str_), fmt::make_args_checked<Args...>(std::data(format_str_), args...));
+        SetValueImpl(std::string_view(format_str_), fmt::format_arg_store<fmt::format_context, Args...>(args...));
     }
 
 private:

--- a/common/include/iostream_error.h
+++ b/common/include/iostream_error.h
@@ -8,7 +8,11 @@
 namespace mmotd::error::ios_flags {
 
 inline std::string to_string(const std::ios &strm) {
-    return fmt::format("good()={}, eof()={}, fail()={}, bad()={}", strm.good(), strm.eof(), strm.fail(), strm.bad());
+    return fmt::format(FMT_STRING("good()={}, eof()={}, fail()={}, bad()={}"),
+                       strm.good(),
+                       strm.eof(),
+                       strm.fail(),
+                       strm.bad());
 }
 
 } // namespace mmotd::error::ios_flags

--- a/common/results/src/output_column.cpp
+++ b/common/results/src/output_column.cpp
@@ -49,7 +49,10 @@ void Column::AddNamesValues(const Informations &informations, PositionIndex posi
         row.SetNameValue(informations);
     }
     for (const auto &row : rows_) {
-        PLOG_VERBOSE << format("row[{}] = [{}] {}", row.GetRowNumber(), fmt::ptr(&row), row.item_to_string());
+        PLOG_VERBOSE << format(FMT_STRING("row[{}] = [{}] {}"),
+                               row.GetRowNumber(),
+                               fmt::ptr(&row),
+                               row.item_to_string());
     }
 }
 
@@ -83,38 +86,38 @@ bool Column::HasPreviousRow(RowId row_id) const {
 
 const Row &Column::GetPreviousRow(RowId row_id) const {
     auto i = find_if(begin(rows_), end(rows_), [row_id](auto &row) { return row.GetId() == row_id; });
-    MMOTD_CHECKS(i != end(rows_), format("row id '{}' was not found", boost::uuids::to_string(row_id)));
+    MMOTD_CHECKS(i != end(rows_), format(FMT_STRING("row id '{}' was not found"), boost::uuids::to_string(row_id)));
     return *(i - 1);
 }
 
 Row &Column::GetPreviousRow(RowId row_id) {
     auto i = find_if(begin(rows_), end(rows_), [row_id](auto &row) { return row.GetId() == row_id; });
-    MMOTD_CHECKS(i != end(rows_), format("row id '{}' was not found", boost::uuids::to_string(row_id)));
+    MMOTD_CHECKS(i != end(rows_), format(FMT_STRING("row id '{}' was not found"), boost::uuids::to_string(row_id)));
     return *(i - 1);
 }
 
 const Row &Column::GetRow(RowId row_id) const {
     auto i = find_if(begin(rows_), end(rows_), [row_id](auto &row) { return row.GetId() == row_id; });
-    MMOTD_CHECKS(i != end(rows_), format("row id '{}' was not found", boost::uuids::to_string(row_id)));
+    MMOTD_CHECKS(i != end(rows_), format(FMT_STRING("row id '{}' was not found"), boost::uuids::to_string(row_id)));
     return *i;
 }
 
 Row &Column::GetRow(RowId row_id) {
     auto i = find_if(begin(rows_), end(rows_), [row_id](auto &row) { return row.GetId() == row_id; });
-    MMOTD_CHECKS(i != end(rows_), format("row id '{}' was not found", boost::uuids::to_string(row_id)));
+    MMOTD_CHECKS(i != end(rows_), format(FMT_STRING("row id '{}' was not found"), boost::uuids::to_string(row_id)));
     return *i;
 }
 
 Row &Column::GetRow(int row_number) {
     auto i = find_if(begin(rows_), end(rows_), [row_number](auto &row) { return row.GetRowNumber() == row_number; });
-    MMOTD_CHECKS(i != end(rows_), format("row number '{}' was not found", row_number));
+    MMOTD_CHECKS(i != end(rows_), format(FMT_STRING("row number '{}' was not found"), row_number));
     return *i;
 }
 
 const Row &Column::GetRow(int row_number) const {
     auto i =
         find_if(begin(rows_), end(rows_), [row_number](const auto &row) { return row.GetRowNumber() == row_number; });
-    MMOTD_CHECKS(i != end(rows_), format("row number '{}' was not found", row_number));
+    MMOTD_CHECKS(i != end(rows_), format(FMT_STRING("row number '{}' was not found"), row_number));
     return *i;
 }
 

--- a/common/results/src/output_frame.cpp
+++ b/common/results/src/output_frame.cpp
@@ -67,7 +67,7 @@ const Column &Frame::GetColumn(ColumnIndex index) const {
         return idx == index;
     });
     if (i == end(columns_)) {
-        MMOTD_THROW_OUT_OF_RANGE(format("column index {} not found in template columns", index));
+        MMOTD_THROW_OUT_OF_RANGE(format(FMT_STRING("column index {} not found in template columns"), index));
     }
     const auto &[_, column] = *i;
     return column;
@@ -79,7 +79,7 @@ Column &Frame::GetColumn(ColumnIndex index) {
         return idx == index;
     });
     if (i == end(columns_)) {
-        MMOTD_THROW_OUT_OF_RANGE(format("column index {} not found in template columns", index));
+        MMOTD_THROW_OUT_OF_RANGE(format(FMT_STRING("column index {} not found in template columns"), index));
     }
     auto &[_, column] = *i;
     return column;
@@ -92,7 +92,7 @@ const Column &Frame::GetColumn(RowId row_id) const {
             return column;
         }
     }
-    MMOTD_THROW_OUT_OF_RANGE(format("row id {} not found in any columns", boost::uuids::to_string(row_id)));
+    MMOTD_THROW_OUT_OF_RANGE(format(FMT_STRING("row id {} not found in any columns"), boost::uuids::to_string(row_id)));
     static const auto INVALID_COLUMN = Column{};
     return INVALID_COLUMN;
 }
@@ -104,7 +104,7 @@ Column &Frame::GetColumn(RowId row_id) {
             return column;
         }
     }
-    MMOTD_THROW_OUT_OF_RANGE(format("row id {} not found in any columns", boost::uuids::to_string(row_id)));
+    MMOTD_THROW_OUT_OF_RANGE(format(FMT_STRING("row id {} not found in any columns"), boost::uuids::to_string(row_id)));
     static auto INVALID_COLUMN = Column{};
     return INVALID_COLUMN;
 }
@@ -175,7 +175,7 @@ void Frame::RemoveEmptyRows() {
     auto row_numbers = GetFirstLastRowNumbers();
     for (auto i = begin(row_numbers); i != end(row_numbers); ++i) {
         auto row_number = *i;
-        PLOG_VERBOSE << format("inspecting row: {}, empty rows: {}", row_number, empty_row_count);
+        PLOG_VERBOSE << format(FMT_STRING("inspecting row: {}, empty rows: {}"), row_number, empty_row_count);
         auto row_ids = GetRowIds(row_number);
         if (empty(row_ids)) {
             ++empty_row_count;
@@ -296,7 +296,7 @@ size_t Frame::GetColumnCount(bool include_name_value) const {
             }
         }
     }
-    PLOG_VERBOSE << format("column count: {}, include name value: {}", total_count, include_name_value);
+    PLOG_VERBOSE << format(FMT_STRING("column count: {}, include name value: {}"), total_count, include_name_value);
     return total_count;
 }
 
@@ -306,7 +306,7 @@ const Row &Frame::GetRow(RowId row_id) const {
         const auto &column = GetColumn(index);
         return column.ContainsRow(row_id);
     });
-    MMOTD_CHECKS(i != end(indexes), format("unable to find row id: {}", boost::uuids::to_string(row_id)));
+    MMOTD_CHECKS(i != end(indexes), format(FMT_STRING("unable to find row id: {}"), boost::uuids::to_string(row_id)));
     return GetColumn(*i).GetRow(row_id);
 }
 
@@ -316,7 +316,7 @@ Row &Frame::GetRow(RowId row_id) {
         const auto &column = GetColumn(index);
         return column.ContainsRow(row_id);
     });
-    MMOTD_CHECKS(i != end(indexes), format("unable to find row id: {}", boost::uuids::to_string(row_id)));
+    MMOTD_CHECKS(i != end(indexes), format(FMT_STRING("unable to find row id: {}"), boost::uuids::to_string(row_id)));
     return GetColumn(*i).GetRow(row_id);
 }
 

--- a/common/results/src/output_row.cpp
+++ b/common/results/src/output_row.cpp
@@ -82,7 +82,7 @@ bool Row::BalanceNameValueSize() {
 
 size_t Row::UpdateRowNumber(int row_number) {
     MMOTD_PRECONDITIONS(size(names_) == size(values_), "output names and values must be equal sizes");
-    PLOG_VERBOSE << format("updating row number: {} to: {} for name: '{}', value: '{}'",
+    PLOG_VERBOSE << format(FMT_STRING("updating row number: {} to: {} for name: '{}', value: '{}'"),
                            item_.row_index,
                            row_number,
                            GetName(0),
@@ -96,14 +96,14 @@ void Row::SetNameValue(const Informations &informations) {
         auto template_string = TemplateString{sub_name};
         auto modified_name =
             template_string.TransformTemplateName(informations, item_, static_cast<size_t>(item_.repeatable_index));
-        PLOG_VERBOSE << format("adding name to row {}: '{}'", GetRowNumber(), modified_name);
+        PLOG_VERBOSE << format(FMT_STRING("adding name to row {}: '{}'"), GetRowNumber(), modified_name);
         AddName(modified_name);
     }
     for (const auto &sub_value : item_.value) {
         auto template_string = TemplateString{sub_value};
         auto modified_value =
             template_string.TransformTemplateValue(informations, item_, static_cast<size_t>(item_.repeatable_index));
-        PLOG_VERBOSE << format("adding value to row {}: '{}'", GetRowNumber(), modified_value);
+        PLOG_VERBOSE << format(FMT_STRING("adding value to row {}: '{}'"), GetRowNumber(), modified_value);
         AddValue(modified_value);
     }
 }

--- a/common/results/src/output_row_number_sentinals.cpp
+++ b/common/results/src/output_row_number_sentinals.cpp
@@ -16,7 +16,7 @@ static constexpr const int INVALID_ROW = std::numeric_limits<int>::max();
 namespace mmotd::results {
 
 RowNumberSentinals::RowNumberSentinals(value_type begin, value_type end) : begin_value_(begin), end_value_(end) {
-    PLOG_VERBOSE << format("row sentinal created: {}", to_string());
+    PLOG_VERBOSE << format(FMT_STRING("row sentinal created: {}"), to_string());
 }
 
 RowNumberSentinals::iterator RowNumberSentinals::begin() {
@@ -219,7 +219,7 @@ string RowNumberSentinals::to_string() const {
     if (begin_value_ == INVALID_ROW || end_value_ == INVALID_ROW) {
         return string{"{INVALID : INVALID}"};
     } else {
-        return format("{{{} : {}}}", begin_value_, end_value_);
+        return format(FMT_STRING("{{{} : {}}}"), begin_value_, end_value_);
     }
 }
 

--- a/common/results/src/output_table.cpp
+++ b/common/results/src/output_table.cpp
@@ -132,13 +132,13 @@ private:
 };
 
 Table::TableImpl::TableImpl(string table_style, size_t column_count) : table_(), column_count_(column_count) {
-    PLOG_VERBOSE << format("setting border style: {}", table_style);
+    PLOG_VERBOSE << format(FMT_STRING("setting border style: {}"), table_style);
     GetTable().set_border_style(GetTableStyle(table_style));
     PLOG_VERBOSE << "setting ft_set_u8strwid_func to custom: GetStringWidth";
     ft_set_u8strwid_func(&GetStringWidth);
     PLOG_VERBOSE << "setting adding strategy: replace";
     GetTable().set_adding_strategy(fort::add_strategy::replace);
-    PLOG_VERBOSE << format("setting right margin: {}", GetColumnCount());
+    PLOG_VERBOSE << format(FMT_STRING("setting right margin: {}"), GetColumnCount());
     GetTable().set_right_margin(static_cast<unsigned>(GetColumnCount()));
 }
 
@@ -150,7 +150,7 @@ void Table::TableImpl::WriteRow(const Row &row) {
     auto already_written_name = false;
     auto row_line_count = row.GetHeight();
     for (auto i = size_t{0}; i != row_line_count; ++i) {
-        PLOG_VERBOSE << format("writing [{}][{}] {} column",
+        PLOG_VERBOSE << format(FMT_STRING("writing [{}][{}] {} column"),
                                row.GetRowNumber(),
                                row.GetColumnNumberStr(),
                                row.GetColumnPosition().to_string());
@@ -193,11 +193,14 @@ void Table::TableImpl::WriteCell(string text,
                                  size_t col_number,
                                  size_t cell_span,
                                  bool use_cell_span) {
-    PLOG_VERBOSE << format("setting right margin: {}", GetColumnCount());
+    PLOG_VERBOSE << format(FMT_STRING("setting right margin: {}"), GetColumnCount());
     GetTable().set_right_margin(static_cast<unsigned>(GetColumnCount()));
-    auto debug_str = "writing cell, row: {}, column: {}, cell span: {}, text: '{}'";
     auto cell_span_str = use_cell_span ? ::to_string(cell_span) : string{"none"};
-    PLOG_VERBOSE << format(debug_str, row_number, col_number, cell_span_str, text);
+    PLOG_VERBOSE << format(FMT_STRING("writing cell, row: {}, column: {}, cell span: {}, text: '{}'"),
+                           row_number,
+                           col_number,
+                           cell_span_str,
+                           text);
     GetTable().set_cur_cell(row_number, col_number);
     if (use_cell_span) {
         GetTable().cur_cell().set_cell_span(cell_span);
@@ -210,9 +213,9 @@ void Table::TableImpl::WriteNameValue(const Row &row, size_t line_index) {
     auto column_position = row.GetColumnPosition();
     auto column_number = column_position.GetIndex() * row.GetColumnCount();
     auto cell_span = GetColumnCount() - 1;
-    auto text = format("{}{}", GetRowPrefix(row), row.GetName(line_index));
+    auto text = format(FMT_STRING("{}{}"), GetRowPrefix(row), row.GetName(line_index));
     WriteCell(text, row_number, column_number, size_t{0}, false);
-    text = format("{}{}", row.GetValue(line_index), GetRowSuffix(row, line_index));
+    text = format(FMT_STRING("{}{}"), row.GetValue(line_index), GetRowSuffix(row, line_index));
     WriteCell(text, row_number, column_number + 1, cell_span, column_position.IsEntireLine());
 }
 
@@ -221,7 +224,7 @@ void Table::TableImpl::WriteName(const Row &row, size_t line_index) {
     auto column_position = row.GetColumnPosition();
     auto column_number = column_position.GetIndex() * row.GetColumnCount();
     auto cell_span = GetColumnCount() - 1;
-    auto text = format("{}{}{}", GetRowPrefix(row), row.GetName(line_index), GetRowSuffix(row, line_index));
+    auto text = format(FMT_STRING("{}{}{}"), GetRowPrefix(row), row.GetName(line_index), GetRowSuffix(row, line_index));
     WriteCell(text, row_number, column_number, cell_span, column_position.IsEntireLine());
 }
 
@@ -231,7 +234,8 @@ void Table::TableImpl::WriteValue(const Row &row, size_t line_index, bool bump_c
     auto column_number = column_position.GetIndex() * row.GetColumnCount();
     column_number += bump_column ? 1 : 0;
     auto cell_span = bump_column ? GetColumnCount() - 1 : GetColumnCount();
-    auto text = format("{}{}{}", GetRowPrefix(row), row.GetValue(line_index), GetRowSuffix(row, line_index));
+    auto text =
+        format(FMT_STRING("{}{}{}"), GetRowPrefix(row), row.GetValue(line_index), GetRowSuffix(row, line_index));
     WriteCell(text, row_number, column_number, cell_span, column_position.IsEntireLine());
 }
 

--- a/common/results/src/output_template.cpp
+++ b/common/results/src/output_template.cpp
@@ -47,7 +47,7 @@ string OutputTemplate::GetDefaultTemplate() const {
 bool OutputTemplate::ParseTemplateFile(string template_file_name) {
     auto ec = std::error_code{};
     if (auto file_exists = fs::exists(template_file_name, ec); !file_exists || ec) {
-        PLOG_ERROR << format("determining whether template file {} exists", template_file_name);
+        PLOG_ERROR << format(FMT_STRING("determining whether template file {} exists"), template_file_name);
         return false;
     }
     return ParseJson(template_file_name);
@@ -82,11 +82,11 @@ unique_ptr<OutputTemplate> MakeOutputTemplate(string template_file_name) {
                    nullptr;
     } catch (boost::exception &ex) {
         auto diag = boost::diagnostic_information(ex);
-        auto error_str = format("caught boost::exception in creating template: {}", diag);
+        auto error_str = format(FMT_STRING("caught boost::exception in creating template: {}"), diag);
         PLOG_ERROR << error_str;
         return nullptr;
     } catch (const std::exception &ex) {
-        auto error_str = format("caught std::exception in creating template: {}", ex.what());
+        auto error_str = format(FMT_STRING("caught std::exception in creating template: {}"), ex.what());
         PLOG_ERROR << error_str;
         return nullptr;
     }
@@ -99,10 +99,10 @@ void CreateDefaultOutputTemplate(string template_file_name) {
         ostrm.flush();
     } catch (boost::exception &ex) {
         auto diag = boost::diagnostic_information(ex);
-        auto error_str = format("caught boost::exception in creating template: {}", diag);
+        auto error_str = format(FMT_STRING("caught boost::exception in creating template: {}"), diag);
         PLOG_ERROR << error_str;
     } catch (const std::exception &ex) {
-        auto error_str = format("caught std::exception in creating template: {}", ex.what());
+        auto error_str = format(FMT_STRING("caught std::exception in creating template: {}"), ex.what());
         PLOG_ERROR << error_str;
     }
 }

--- a/common/results/src/output_template_printer.cpp
+++ b/common/results/src/output_template_printer.cpp
@@ -8,7 +8,7 @@ namespace mmotd::results {
 
 void PrintOutputTemplate(const OutputTemplate &output_template, const mmotd::information::Informations &informations) {
     auto frame = Frame::CreateFrame(output_template, informations);
-    fmt::print("{}", frame.to_string());
+    fmt::print(FMT_STRING("{}"), frame.to_string());
 }
 
 } // namespace mmotd::results

--- a/common/results/src/template_string.cpp
+++ b/common/results/src/template_string.cpp
@@ -48,7 +48,7 @@ optional<Information> TemplateString::FindInformation(const string &information_
         },
         [](const auto &information) { return &information; });
     if (information_index >= std::size(information_ptrs)) {
-        PLOG_ERROR << format("attempting to find the index={} of id={} when there is only {} of that id",
+        PLOG_ERROR << format(FMT_STRING("attempting to find the index={} of id={} when there is only {} of that id"),
                              information_index,
                              information_id,
                              std::size(information_ptrs));
@@ -65,12 +65,12 @@ optional<string> TemplateString::GetInformationValue(const string &information_i
                                                      size_t information_index) {
     auto information_holder = TemplateString::FindInformation(information_id, informations, information_index);
     if (!information_holder) {
-        PLOG_ERROR << format("unable to find information id {}", information_id);
+        PLOG_ERROR << format(FMT_STRING("unable to find information id {}"), information_id);
         return nullopt;
     }
     const auto &information = *information_holder;
     auto information_value = information.GetValue();
-    PLOG_VERBOSE << format("found {} with value {}", information_id, information_value);
+    PLOG_VERBOSE << format(FMT_STRING("found {} with value {}"), information_id, information_value);
     return make_optional(information_value);
 }
 
@@ -80,7 +80,7 @@ TemplateString::ReplaceInformationIds(const string &text, const Informations &in
         return text;
     }
 
-    PLOG_VERBOSE << format("template str: {}", text);
+    PLOG_VERBOSE << format(FMT_STRING("template str: {}"), text);
     const auto pattern = regex(R"(%(ID_[_A-Z]+)%)");
     auto replacement_token = sregex_iterator(begin(text), end(text), pattern);
 
@@ -88,13 +88,13 @@ TemplateString::ReplaceInformationIds(const string &text, const Informations &in
     auto index = size_t{0};
     for (auto i = replacement_token; i != sregex_iterator{}; ++i) {
         auto match = *i;
-        PLOG_VERBOSE << format("index: {}, pos: {}, len: {}, iterator: {}",
+        PLOG_VERBOSE << format(FMT_STRING("index: {}, pos: {}, len: {}, iterator: {}"),
                                index,
                                match.position(),
                                match.length(),
                                match.str());
         if (match.position() > static_cast<ptrdiff_t>(index)) {
-            PLOG_VERBOSE << format("adding prefix: \"{}\"",
+            PLOG_VERBOSE << format(FMT_STRING("adding prefix: \"{}\""),
                                    text.substr(index, static_cast<size_t>(match.position()) - index));
             formatted_str += text.substr(index, static_cast<size_t>(match.position()) - index);
         }
@@ -104,10 +104,10 @@ TemplateString::ReplaceInformationIds(const string &text, const Informations &in
         }
     }
     if (index < size(text)) {
-        PLOG_VERBOSE << format("adding suffix: \"{}\"", text.substr(index));
+        PLOG_VERBOSE << format(FMT_STRING("adding suffix: \"{}\""), text.substr(index));
         formatted_str += text.substr(index);
     }
-    PLOG_VERBOSE << format("formatted: {}", formatted_str);
+    PLOG_VERBOSE << format(FMT_STRING("formatted: {}"), formatted_str);
     return formatted_str;
 }
 
@@ -124,10 +124,10 @@ InformationId TemplateString::FindFirstInformationId(const string &text, const I
 
 vector<string> TemplateString::SplitColorCodeDefinitions(const string &color_str, const char delimeter) {
     if (std::empty(color_str)) {
-        PLOG_VERBOSE << format("input is empty delim='{}', input=\"{}\"", delimeter, color_str);
+        PLOG_VERBOSE << format(FMT_STRING("input is empty delim='{}', input=\"{}\""), delimeter, color_str);
         return vector<string>{};
     } else if (color_str.front() != delimeter || color_str.back() != delimeter) {
-        PLOG_VERBOSE << format("input is not wrapped by delim='{}', input=\"{}\"", delimeter, color_str);
+        PLOG_VERBOSE << format(FMT_STRING("input is not wrapped by delim='{}', input=\"{}\""), delimeter, color_str);
         return vector<string>{color_str};
     }
     auto color_definitions = vector<string>{};
@@ -140,7 +140,7 @@ vector<string> TemplateString::SplitColorCodeDefinitions(const string &color_str
             auto str_end = cbegin(color_str) + static_cast<ptrdiff_t>(index);
             color_definitions.push_back(string{str_begin, str_end});
             index += std::size(string(size_t{2}, delimeter));
-            PLOG_VERBOSE << format("found {}, index={}, in=\"{}\", created color def=\"{}\"",
+            PLOG_VERBOSE << format(FMT_STRING("found {}, index={}, in=\"{}\", created color def=\"{}\""),
                                    string(size_t{2}, delimeter),
                                    index,
                                    color_str,
@@ -149,7 +149,7 @@ vector<string> TemplateString::SplitColorCodeDefinitions(const string &color_str
             auto str_begin = cbegin(color_str) + previous;
             auto str_end = cend(color_str) - 1;
             color_definitions.push_back(string{str_begin, str_end});
-            PLOG_VERBOSE << format("unable to find {}, index={}, in=\"{}\", created color def=\"{}\"",
+            PLOG_VERBOSE << format(FMT_STRING("unable to find {}, index={}, in=\"{}\", created color def=\"{}\""),
                                    string(size_t{2}, delimeter),
                                    previous,
                                    color_str,
@@ -199,7 +199,7 @@ void TemplateString::CreateTemplateSubstring(const string &text,
     }
 
     template_substrings.emplace_back(make_unique<TemplateSubstring>(text, prefix, substring_text, color_definitions));
-    PLOG_VERBOSE << format("created template substring=\"{}\" from \"{}\"",
+    PLOG_VERBOSE << format(FMT_STRING("created template substring=\"{}\" from \"{}\""),
                            template_substrings.back().to_string(),
                            text);
 }
@@ -208,17 +208,17 @@ void TemplateString::UpdateLastTemplateSubstring(const string &text,
                                                  TemplateSubstrings &template_substrings,
                                                  size_t next_template_substring_position) {
     if (std::empty(template_substrings)) {
-        PLOG_VERBOSE << format("there was no previous substring to updated end marker in \"{}\"", text);
+        PLOG_VERBOSE << format(FMT_STRING("there was no previous substring to updated end marker in \"{}\""), text);
         return;
     }
 
-    PLOG_VERBOSE << format("updating previous substring end marker to {} in \"{}\"",
+    PLOG_VERBOSE << format(FMT_STRING("updating previous substring end marker to {} in \"{}\""),
                            next_template_substring_position,
                            text);
     auto previous_range = template_substrings.back().GetSubstringRange();
     auto new_range = SubstringRange{previous_range.position(), next_template_substring_position};
     if (previous_range == new_range) {
-        PLOG_VERBOSE << format("both new and existing substrings are equal [{}:{}], [{}:{}] in \"{}\"",
+        PLOG_VERBOSE << format(FMT_STRING("both new and existing substrings are equal [{}:{}], [{}:{}] in \"{}\""),
                                previous_range.position(),
                                previous_range.size(),
                                new_range.position(),
@@ -227,27 +227,30 @@ void TemplateString::UpdateLastTemplateSubstring(const string &text,
         return;
     }
 
-    PLOG_VERBOSE << format("setting substring text from [{}:{}] to [{}:{}] in \"{}\"",
+    PLOG_VERBOSE << format(FMT_STRING("setting substring text from [{}:{}] to [{}:{}] in \"{}\""),
                            previous_range.position(),
                            previous_range.size(),
                            new_range.position(),
                            new_range.size(),
                            text);
     template_substrings.back().SetSubstringText(new_range);
-    PLOG_VERBOSE << format("new substring text \"{}\" in \"{}\"", template_substrings.back().GetSubstring(), text);
+    PLOG_VERBOSE << format(FMT_STRING("new substring text \"{}\" in \"{}\""),
+                           template_substrings.back().GetSubstring(),
+                           text);
 }
 
 bool TemplateString::IsColorCodeMatchValid(const string &text, const smatch &matches) {
     if (static_cast<size_t>(matches.position()) > std::size(text) ||
         static_cast<size_t>(matches.position() + matches.length()) > std::size(text)) {
-        PLOG_ERROR << format("color definition is beyond EOS, match start={}, match len={}, str size={}, str={}",
-                             matches.position(),
-                             matches.length(),
-                             std::size(text),
-                             text);
+        PLOG_ERROR << format(
+            FMT_STRING("color definition is beyond EOS, match start={}, match len={}, str size={}, str={}"),
+            matches.position(),
+            matches.length(),
+            std::size(text),
+            text);
         return false;
     }
-    PLOG_VERBOSE << format("color definition is valid start={}, len={}, str size={}, match={}, str={}",
+    PLOG_VERBOSE << format(FMT_STRING("color definition is valid start={}, len={}, str size={}, match={}, str={}"),
                            matches.position(),
                            matches.length(),
                            std::size(text),
@@ -264,7 +267,7 @@ void TemplateString::ParseColorCodeSubstring(const string &text,
 
     if (!regex_search(cbegin(text) + static_cast<ptrdiff_t>(index), cend(text), matches, regex_color_pattern)) {
         auto input_substr = string_view{text.c_str() + index};
-        PLOG_VERBOSE << format("color code not found in \"{}\"", input_substr);
+        PLOG_VERBOSE << format(FMT_STRING("color code not found in \"{}\""), input_substr);
         TemplateString::UpdateLastTemplateSubstring(text, template_substrings, std::size(text));
         index = std::size(text);
         return;
@@ -278,7 +281,7 @@ void TemplateString::ParseColorCodeSubstring(const string &text,
     auto match_substr = string{cbegin(text) + static_cast<ptrdiff_t>(index) + matches.position(),
                                cbegin(text) + static_cast<ptrdiff_t>(index) + matches.position() + matches.length()};
     auto input_substr = string_view{text.c_str() + index};
-    PLOG_VERBOSE << format("color code found match={}, text=\"{}\"", match_substr, input_substr);
+    PLOG_VERBOSE << format(FMT_STRING("color code found match={}, text=\"{}\""), match_substr, input_substr);
 
     auto prefix = SubstringRange{};
     if (!std::empty(template_substrings)) {
@@ -310,7 +313,8 @@ TemplateSubstrings TemplateString::GenerateTemplateSubstrings(const string &text
                                                                             ColorDefinitions{}));
         }
     }
-    PLOG_ERROR_IF(loop_count == 10) << format("parse color code exited after 10 iterations, text=\"{}\"", text);
+    PLOG_ERROR_IF(loop_count == 10) << format(FMT_STRING("parse color code exited after 10 iterations, text=\"{}\""),
+                                              text);
     return template_substrings;
 }
 
@@ -331,7 +335,7 @@ string TemplateString::ReplaceEmbeddedColorCodes(TemplateType template_type,
     if (AppOptions::Instance().GetOptions().IsColorDisabled()) {
         return formatted_str;
     } else {
-        return format(color_style, formatted_str);
+        return format(color_style, FMT_STRING("{}"), formatted_str);
     }
 }
 
@@ -341,9 +345,9 @@ string TemplateString::TransformTemplate(TemplateType template_type,
                                          const TemplateColumnItem &item,
                                          size_t information_index) {
     auto updated_text1 = TemplateString::ReplaceInformationIds(text, informations, information_index);
-    PLOG_VERBOSE << format("transforming \"{}\" to \"{}\"", text, updated_text1);
+    PLOG_VERBOSE << format(FMT_STRING("transforming \"{}\" to \"{}\""), text, updated_text1);
     auto updated_text2 = TemplateString::ReplaceEmbeddedColorCodes(template_type, updated_text1, item);
-    PLOG_VERBOSE << format("transformed \"{}\" to \"{}\"", updated_text1, updated_text2);
+    PLOG_VERBOSE << format(FMT_STRING("transformed \"{}\" to \"{}\""), updated_text1, updated_text2);
     return updated_text2;
 }
 

--- a/common/results/src/template_substrings.cpp
+++ b/common/results/src/template_substrings.cpp
@@ -101,7 +101,7 @@ string TemplateSubstrings::to_string(function<fmt::text_style(string)> convert_c
     auto i = size_t{0};
     for (const auto &template_substring : *this) {
         auto substring_output = template_substring.to_string(convert_color);
-        PLOG_VERBOSE << format("{}: formatted text=\"{}\"", i, substring_output);
+        PLOG_VERBOSE << format(FMT_STRING("{}: formatted text=\"{}\""), i, substring_output);
         output += substring_output;
     }
     return output;

--- a/common/src/app_options.cpp
+++ b/common/src/app_options.cpp
@@ -20,7 +20,7 @@ namespace {
 optional<string> GetEnvironmentVariableValue(string variable_name) {
     auto env_value = getenv(variable_name.c_str());
     if (env_value == nullptr) {
-        PLOG_ERROR << format("getenv failed when attempting to look up variable {}", variable_name);
+        PLOG_ERROR << format(FMT_STRING("getenv failed when attempting to look up variable {}"), variable_name);
         return nullopt;
     }
     return make_optional(string{env_value});
@@ -36,10 +36,10 @@ auto GetDefaultTemplatePath() {
     auto ec = error_code{};
     if (fs::exists(template_path, ec) && !ec &&
         ((fs::is_regular_file(template_path, ec) && !ec) || (fs::is_symlink(template_path, ec) && !ec))) {
-        PLOG_VERBOSE << format("found the default mmotd template ({})", template_path.string());
+        PLOG_VERBOSE << format(FMT_STRING("found the default mmotd template ({})"), template_path.string());
         return template_path;
     } else {
-        PLOG_ERROR << format("unable to locate the default mmotd template ({})", template_path.string());
+        PLOG_ERROR << format(FMT_STRING("unable to locate the default mmotd template ({})"), template_path.string());
         return fs::path{};
     }
 }
@@ -49,12 +49,12 @@ void append_option(string &existing_options_str, const string &name, T is_set, U
     if (!existing_options_str.empty()) {
         existing_options_str += "\n";
     }
-    existing_options_str += format("  {} [{}]: {}", name, is_set() ? "SET" : "UNSET", get_value());
+    existing_options_str += format(FMT_STRING("  {} [{}]: {}"), name, is_set() ? "SET" : "UNSET", get_value());
 }
 
 auto IsStdoutTtyImpl() {
     auto is_stdout_tty = isatty(STDOUT_FILENO) != 0;
-    PLOG_VERBOSE << format("stdout is{} a tty", is_stdout_tty ? "" : " not");
+    PLOG_VERBOSE << format(FMT_STRING("stdout is{} a tty"), is_stdout_tty ? "" : " not");
     return is_stdout_tty;
 }
 

--- a/common/src/information_definitions.cpp
+++ b/common/src/information_definitions.cpp
@@ -29,7 +29,7 @@ const InformationDefinitions &InformationDefinitions::Instance() {
 Information InformationDefinitions::GetInformationDefinition(InformationId id) const {
     auto i = find_if(begin(informations_), end(informations_), [id](const auto &info) { return info.GetId() == id; });
     if (i == end(informations_)) {
-        auto msg = format("unable to find information id={}", id);
+        auto msg = format(FMT_STRING("unable to find information id={}"), id);
         MMOTD_THROW_RUNTIME_ERROR(msg);
     }
     return *i;

--- a/common/src/logging.cpp
+++ b/common/src/logging.cpp
@@ -31,6 +31,17 @@ void DefaultInitializeLogging(const string &filename) {
     plog::init<CONSOLE_LOG>(gConsoleAppenderVerbosity, &console_appender);
 }
 
+// enum Severity
+// {
+//     none = 0,
+//     fatal = 1,
+//     error = 2,
+//     warning = 3,
+//     info = 4,
+//     debug = 5,
+//     verbose = 6
+// };
+
 static plog::Severity convert_verbosity(size_t verbosity) {
     if (verbosity == 0) {
         return plog::none;
@@ -42,6 +53,9 @@ static plog::Severity convert_verbosity(size_t verbosity) {
     }
 }
 
+// verbosity is a 0-based value where 0=none, 1=info, 2=debug, 3=verbose
+//  conversion from this range to the `plog::Severity` is a simple off by 3
+//  calculation where the ceil is 6=verbose.
 void UpdateSeverityFilter(size_t verbosity) {
     plog::Severity new_severity = convert_verbosity(verbosity);
     auto new_file_severity = std::max(new_severity, gFileAppenderVerbosity);

--- a/common/src/mac_address.cpp
+++ b/common/src/mac_address.cpp
@@ -51,7 +51,8 @@ MacAddress MacAddress::from_string(const std::string &input_str) {
 
     // if the number of elements are still not == 6 then we have malformed input
     if (mac_addr_hex_chars.size() != MAC_ADDRESS_SIZE) {
-        auto error_str = format("mac address is not the correct length (size={} != 6)", mac_addr_hex_chars.size());
+        auto error_str =
+            format(FMT_STRING("mac address is not the correct length (size={} != 6)"), mac_addr_hex_chars.size());
         MMOTD_THROW_INVALID_ARGUMENT(error_str);
     }
 
@@ -63,7 +64,7 @@ MacAddress MacAddress::from_string(const std::string &input_str) {
               [&input_str](const auto &hex_char) {
                   if (!all(hex_char, is_xdigit()) || hex_char.empty() || hex_char.size() > 2) {
                       auto error_str =
-                          format("invalid character (\"{}\") found in mac address {}", hex_char, input_str);
+                          format(FMT_STRING("invalid character (\"{}\") found in mac address {}"), hex_char, input_str);
                       MMOTD_THROW_INVALID_ARGUMENT(error_str);
                   }
                   auto value = std::stoul(hex_char, nullptr, 16);
@@ -80,7 +81,7 @@ bool MacAddress::IsZero() const {
 }
 
 string MacAddress::to_string() const {
-    return format("{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+    return format(FMT_STRING("{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}"),
                   static_cast<uint32_t>(data_[0]),
                   static_cast<uint32_t>(data_[1]),
                   static_cast<uint32_t>(data_[2]),

--- a/common/src/version.cpp
+++ b/common/src/version.cpp
@@ -51,7 +51,9 @@ int32_t FromString(string_view str) {
     auto result = int32_t{0};
     auto [ptr, ec] = std::from_chars(begin(str), end(str), result);
     if (ec != std::errc{}) {
-        PLOG_ERROR << format("unable to convert {} into an integer, {}", str, make_error_code(ec).message());
+        PLOG_ERROR << format(FMT_STRING("unable to convert {} into an integer, {}"),
+                             str,
+                             make_error_code(ec).message());
     }
     return result;
 }
@@ -68,11 +70,11 @@ optional<version> version::from_string(string_view str) {
       (?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$)"_verbose; // build number
 
     const auto &pattern = REGEX_SEMVER_PATTERN;
-    PLOG_INFO << format("pattern should now match verbose mode \"{}\"", pattern);
+    PLOG_INFO << format(FMT_STRING("pattern should now match verbose mode \"{}\""), pattern);
     auto semver_regex = regex(pattern);
     auto matches = std::cmatch{};
     if (!std::regex_match(begin(str), end(str), matches, semver_regex)) {
-        PLOG_ERROR << format("version {} is not a semver compliant version string", str);
+        PLOG_ERROR << format(FMT_STRING("version {} is not a semver compliant version string"), str);
         return nullopt;
     }
 
@@ -97,12 +99,12 @@ optional<version> version::from_string(string_view str) {
 }
 
 string version::to_string() const {
-    auto version_str = format("{}.{}.{}", major, minor, patch);
+    auto version_str = format(FMT_STRING("{}.{}.{}"), major, minor, patch);
     if (!prerelease.empty()) {
-        version_str += format("-{}", prerelease);
+        version_str += format(FMT_STRING("-{}"), prerelease);
     }
     if (!build_number.empty()) {
-        version_str += format("+{}", build_number);
+        version_str += format(FMT_STRING("+{}"), build_number);
     }
     return version_str;
 }
@@ -119,7 +121,7 @@ const Version &Version::Instance() {
 Version::Version(string_view str) : version_() {
     auto version_wrapper = mmotd::semver::version::from_string(str);
     if (!version_wrapper) {
-        PLOG_ERROR << format("unable to create semver version from {} version string", str);
+        PLOG_ERROR << format(FMT_STRING("unable to create semver version from {} version string"), str);
     }
     version_ = make_unique<mmotd::semver::version>(version_wrapper ? *version_wrapper : mmotd::semver::version{});
 }

--- a/common/test/src/test_assertion.cpp
+++ b/common/test/src/test_assertion.cpp
@@ -22,7 +22,7 @@ TEST_CASE("Assertion inherits from RuntimeError", "[assertion]") {
 TEST_CASE("Assertion contains context", "[assertion]") {
     auto assertion = Assertion("assertion");
     auto assertion_str = string(assertion.what());
-    fmt::print("{}\n", assertion_str);
+    fmt::print(FMT_STRING("{}\n"), assertion_str);
     CHECK_THAT(assertion_str, Contains("mmotd::assertion::Assertion::Assertion"));
 }
 

--- a/common/test/src/test_exception.cpp
+++ b/common/test/src/test_exception.cpp
@@ -23,7 +23,7 @@ TEST_CASE("InvalidArgument inherits from std::invalid_argument", "[exception]") 
 TEST_CASE("InvalidArgument contains context", "[exception]") {
     auto ex = InvalidArgument("invalid argument");
     auto ex_str = string(ex.what());
-    fmt::print("{}\n", ex_str);
+    fmt::print(FMT_STRING("{}\n"), ex_str);
     CHECK_THAT(ex_str, Contains("mmotd::assertion::InvalidArgument::InvalidArgument"));
 }
 
@@ -36,7 +36,7 @@ TEST_CASE("DomainError inherits from std::domain_error", "[exception]") {
 TEST_CASE("DomainError contains context", "[exception]") {
     auto ex = DomainError("domain error");
     auto ex_str = string(ex.what());
-    fmt::print("{}\n", ex_str);
+    fmt::print(FMT_STRING("{}\n"), ex_str);
     CHECK_THAT(ex_str, Contains("mmotd::assertion::DomainError::DomainError"));
 }
 
@@ -49,7 +49,7 @@ TEST_CASE("LengthError inherits from std::length_error", "[exception]") {
 TEST_CASE("LengthError contains context", "[exception]") {
     auto ex = LengthError("length error");
     auto ex_str = string(ex.what());
-    fmt::print("{}\n", ex_str);
+    fmt::print(FMT_STRING("{}\n"), ex_str);
     CHECK_THAT(ex_str, Contains("mmotd::assertion::LengthError::LengthError"));
 }
 
@@ -62,7 +62,7 @@ TEST_CASE("OutOfRange inherits from std::out_of_range", "[exception]") {
 TEST_CASE("OutOfRange contains context", "[exception]") {
     auto ex = OutOfRange("out of range");
     auto ex_str = string(ex.what());
-    fmt::print("{}\n", ex_str);
+    fmt::print(FMT_STRING("{}\n"), ex_str);
     CHECK_THAT(ex_str, Contains("mmotd::assertion::OutOfRange::OutOfRange"));
 }
 
@@ -75,7 +75,7 @@ TEST_CASE("RuntimeError inherits from std::runtime_error", "[exception]") {
 TEST_CASE("RuntimeError contains context", "[exception]") {
     auto ex = RuntimeError("runtime error");
     auto ex_str = string(ex.what());
-    fmt::print("{}\n", ex_str);
+    fmt::print(FMT_STRING("{}\n"), ex_str);
     CHECK_THAT(ex_str, Contains("mmotd::assertion::RuntimeError::RuntimeError"));
 }
 
@@ -88,7 +88,7 @@ TEST_CASE("RangeError inherits from std::range_error", "[exception]") {
 TEST_CASE("RangeError contains context", "[exception]") {
     auto ex = RangeError("range error");
     auto ex_str = string(ex.what());
-    fmt::print("{}\n", ex_str);
+    fmt::print(FMT_STRING("{}\n"), ex_str);
     CHECK_THAT(ex_str, Contains("mmotd::assertion::RangeError::RangeError"));
 }
 
@@ -101,7 +101,7 @@ TEST_CASE("OverflowError inherits from std::overflow_error", "[exception]") {
 TEST_CASE("OverflowError contains context", "[exception]") {
     auto ex = OverflowError("overflow error");
     auto ex_str = string(ex.what());
-    fmt::print("{}\n", ex_str);
+    fmt::print(FMT_STRING("{}\n"), ex_str);
     CHECK_THAT(ex_str, Contains("mmotd::assertion::OverflowError::OverflowError"));
 }
 
@@ -114,7 +114,7 @@ TEST_CASE("UnderflowError inherits from std::underflow_error", "[exception]") {
 TEST_CASE("UnderflowError contains context", "[exception]") {
     auto ex = UnderflowError("underflow error");
     auto ex_str = string(ex.what());
-    fmt::print("{}\n", ex_str);
+    fmt::print(FMT_STRING("{}\n"), ex_str);
     CHECK_THAT(ex_str, Contains("mmotd::assertion::UnderflowError::UnderflowError"));
 }
 

--- a/lib/src/computer_information.cpp
+++ b/lib/src/computer_information.cpp
@@ -44,7 +44,7 @@ void ComputerInformation::SetInformationProviders() {
     auto &creators = GetInformationProviderCreators();
     information_providers_.resize(creators.size());
     transform(begin(creators), end(creators), begin(information_providers_), [](auto &creator) { return creator(); });
-    PLOG_INFO << format("created {} information providers", information_providers_.size());
+    PLOG_INFO << format(FMT_STRING("created {} information providers"), information_providers_.size());
 }
 
 bool RegisterInformationProvider(InformationProviderCreator creator) {

--- a/lib/src/external_network.cpp
+++ b/lib/src/external_network.cpp
@@ -26,10 +26,10 @@ static const bool external_network_information_factory_registered =
 #if 0
 static void walk_ptree(const pt::ptree &tree, size_t indent) {
     const string data = tree.data();
-    cout << fmt::format("{}data: \"{}\"\n", string(indent, ' '), data);
+    cout << fmt::format(FMT_STRING("{}data: \"{}\"\n"), string(indent, ' '), data);
     for (auto i = begin(tree); i != end(tree); ++i) {
         const auto &child = *i;
-        cout << fmt::format("{}child: \"{}\"\n", string(indent, ' '), child.first);
+        cout << fmt::format(FMT_STRING("{}child: \"{}\"\n"), string(indent, ' '), child.first);
         walk_ptree(child.second, indent + 2);
     }
 }
@@ -62,7 +62,7 @@ bool ExternalNetwork::ParseJsonResponse(const string &response) {
 
     auto retval = false;
     if (auto ip_address_value = tree.get_optional<string>("ip"); ip_address_value) {
-        PLOG_DEBUG << format("found ip address: {} in json response body", *ip_address_value);
+        PLOG_DEBUG << format(FMT_STRING("found ip address: {} in json response body"), *ip_address_value);
         auto ip_address = make_address(*ip_address_value);
         auto ip = GetInfoTemplate(InformationId::ID_EXTERNAL_NETWORK_INFO_EXTERNAL_IP);
         ip.SetValueArgs(ip_address.to_string());
@@ -70,37 +70,37 @@ bool ExternalNetwork::ParseJsonResponse(const string &response) {
         retval = true;
     }
     if (auto city_value = tree.get_optional<string>("city"); city_value) {
-        PLOG_DEBUG << format("found city: {} in json response body", *city_value);
+        PLOG_DEBUG << format(FMT_STRING("found city: {} in json response body"), *city_value);
         auto city = GetInfoTemplate(InformationId::ID_LOCATION_INFO_CITY);
         city.SetValueArgs(*city_value);
         AddInformation(city);
     }
     if (auto country_value = tree.get_optional<string>("country"); country_value) {
-        PLOG_DEBUG << format("found country: {} in json response body", *country_value);
+        PLOG_DEBUG << format(FMT_STRING("found country: {} in json response body"), *country_value);
         auto country = GetInfoTemplate(InformationId::ID_LOCATION_INFO_COUNTRY);
         country.SetValueArgs(*country_value);
         AddInformation(country);
     }
     if (auto gps_location_value = tree.get_optional<string>("loc"); gps_location_value) {
-        PLOG_DEBUG << format("found gps location: {} in json response body", *gps_location_value);
+        PLOG_DEBUG << format(FMT_STRING("found gps location: {} in json response body"), *gps_location_value);
         auto gps = GetInfoTemplate(InformationId::ID_LOCATION_INFO_GPS_LOCATION);
         gps.SetValueArgs(*gps_location_value);
         AddInformation(gps);
     }
     if (auto zip_code_value = tree.get_optional<string>("postal"); zip_code_value) {
-        PLOG_DEBUG << format("found zip code: {} in json response body", *zip_code_value);
+        PLOG_DEBUG << format(FMT_STRING("found zip code: {} in json response body"), *zip_code_value);
         auto zipcode = GetInfoTemplate(InformationId::ID_LOCATION_INFO_ZIP_CODE);
         zipcode.SetValueArgs(*zip_code_value);
         AddInformation(zipcode);
     }
     if (auto state_value = tree.get_optional<string>("region"); state_value) {
-        PLOG_DEBUG << format("found state: {} in json response body", *state_value);
+        PLOG_DEBUG << format(FMT_STRING("found state: {} in json response body"), *state_value);
         auto state = GetInfoTemplate(InformationId::ID_LOCATION_INFO_STATE);
         state.SetValueArgs(*state_value);
         AddInformation(state);
     }
     if (auto timezone_value = tree.get_optional<string>("timezone"); timezone_value) {
-        PLOG_DEBUG << format("found timezone: {} in json response body", *timezone_value);
+        PLOG_DEBUG << format(FMT_STRING("found timezone: {} in json response body"), *timezone_value);
         auto tz = GetInfoTemplate(InformationId::ID_LOCATION_INFO_TIMEZONE);
         tz.SetValueArgs(*timezone_value);
         AddInformation(tz);

--- a/lib/src/file_system.cpp
+++ b/lib/src/file_system.cpp
@@ -23,7 +23,7 @@ bool FileSystem::FindInformation() {
     auto ec = error_code{};
     auto root_fs = std::filesystem::space("/", ec);
     if (ec) {
-        PLOG_ERROR << format("getting fs::space on root file system, details: {}", ec.message());
+        PLOG_ERROR << format(FMT_STRING("getting fs::space on root file system, details: {}"), ec.message());
         return false;
     }
 

--- a/lib/src/fortune.cpp
+++ b/lib/src/fortune.cpp
@@ -98,11 +98,11 @@ struct StrFileHeader {
         if ((flags & Flags::Rotated) != Flags::None) {
             flags_str.push_back("rotated");
         }
-        return format("[{}]", boost::join(flags_str, ", "));
+        return format(FMT_STRING("[{}]"), boost::join(flags_str, ", "));
     }
 
     string to_string() const {
-        return format("version: {}, count: {}, longest: {}, shortest: {}, flags: {}, delim: {}",
+        return format(FMT_STRING("version: {}, count: {}, longest: {}, shortest: {}, flags: {}, delim: {}"),
                       version,
                       count,
                       longest_str,
@@ -117,7 +117,7 @@ struct StrFileHeader {
         longest_str = ntohl(longest_str);
         shortest_str = ntohl(shortest_str);
         flags = static_cast<Flags>(ntohl(static_cast<strfile_type>(flags)));
-        PLOG_VERBOSE << format("STRFILE: {}", to_string());
+        PLOG_VERBOSE << format(FMT_STRING("STRFILE: {}"), to_string());
     }
 };
 
@@ -129,27 +129,27 @@ optional<tuple<fs::path, fs::path>> GetFortuneFiles(const string &fortune_name) 
 
     auto ec = std::error_code{};
     if (fs::is_regular_file(fortune_path, ec) || fs::is_symlink(fortune_path, ec)) {
-        PLOG_VERBOSE << format("file exists: {}", fortune_path.string());
+        PLOG_VERBOSE << format(FMT_STRING("file exists: {}"), fortune_path.string());
     } else if (ec) {
-        PLOG_ERROR << format("error {} when checking if file {} is regular/symlink",
+        PLOG_ERROR << format(FMT_STRING("error {} when checking if file {} is regular/symlink"),
                              ec.message(),
                              fortune_path.string());
         return nullopt;
     } else {
-        PLOG_ERROR << format("file {} is not regular/symlink", fortune_path.string());
+        PLOG_ERROR << format(FMT_STRING("file {} is not regular/symlink"), fortune_path.string());
         return nullopt;
     }
 
     auto fortune_db_path = (fortune_path.parent_path() / fortune_path.stem()).replace_extension(".dat");
     if (fs::is_regular_file(fortune_db_path, ec) || fs::is_symlink(fortune_db_path, ec)) {
-        PLOG_VERBOSE << format("file exists: {}", fortune_db_path.string());
+        PLOG_VERBOSE << format(FMT_STRING("file exists: {}"), fortune_db_path.string());
     } else if (ec) {
-        PLOG_ERROR << format("error {} when checking if file {} is regular/symlink",
+        PLOG_ERROR << format(FMT_STRING("error {} when checking if file {} is regular/symlink"),
                              ec.message(),
                              fortune_db_path.string());
         return nullopt;
     } else {
-        PLOG_ERROR << format("file {} is not regular/symlink", fortune_db_path.string());
+        PLOG_ERROR << format(FMT_STRING("file {} is not regular/symlink"), fortune_db_path.string());
         return nullopt;
     }
 
@@ -158,7 +158,7 @@ optional<tuple<fs::path, fs::path>> GetFortuneFiles(const string &fortune_name) 
 
 optional<uint32_t> ParseSingleFortuneDbData(const vector<uint8_t> &buffer) {
     if (buffer.size() != STRFILE_ENTRY_SIZE) {
-        PLOG_ERROR << format("unable to parse STRFILE when the input is not {}", STRFILE_ENTRY_SIZE);
+        PLOG_ERROR << format(FMT_STRING("unable to parse STRFILE when the input is not {}"), STRFILE_ENTRY_SIZE);
         return nullopt;
     }
 
@@ -168,25 +168,27 @@ optional<uint32_t> ParseSingleFortuneDbData(const vector<uint8_t> &buffer) {
     if (STRFILE_ENTRY_CONTAINS_NULL_INT) {
         auto null_value = *reinterpret_cast<const uint32_t *>(buffer.data() + sizeof(uint32_t));
         if (null_value != 0) {
-            auto error_str =
-                format("STRFILE appears corrupt, uint32_t value {} is not followed by NULL uint32_t (uint32_t={})",
-                       host_offset_value,
-                       null_value);
+            auto error_str = format(
+                FMT_STRING("STRFILE appears corrupt, uint32_t value {} is not followed by NULL uint32_t (uint32_t={})"),
+                host_offset_value,
+                null_value);
             PLOG_ERROR << error_str;
             return nullopt;
         }
     }
 
-    PLOG_VERBOSE << format("parsed the STRFILE database entry, offset: {}", host_offset_value);
+    PLOG_VERBOSE << format(FMT_STRING("parsed the STRFILE database entry, offset: {}"), host_offset_value);
     return make_optional(host_offset_value);
 }
 
 optional<uint32_t>
 ReadRandomFortuneOffset(const fs::path &fortune_db_path, std::ifstream &fortune_db_file, uint32_t file_offset) {
-    PLOG_VERBOSE << format("seeking to offset {} in STRFILE database {}", file_offset, fortune_db_path.string());
+    PLOG_VERBOSE << format(FMT_STRING("seeking to offset {} in STRFILE database {}"),
+                           file_offset,
+                           fortune_db_path.string());
     fortune_db_file.seekg(file_offset, std::ios_base::beg);
     if (!fortune_db_file.good()) {
-        PLOG_ERROR << format("unable to seek to {} in STRFILE database {}, {}",
+        PLOG_ERROR << format(FMT_STRING("unable to seek to {} in STRFILE database {}, {}"),
                              file_offset,
                              fortune_db_path.string(),
                              mmotd::error::ios_flags::to_string(fortune_db_file));
@@ -196,7 +198,7 @@ ReadRandomFortuneOffset(const fs::path &fortune_db_path, std::ifstream &fortune_
     auto buffer = vector<uint8_t>(STRFILE_ENTRY_SIZE, 0);
     fortune_db_file.read(reinterpret_cast<char *>(buffer.data()), buffer.size());
     if (fortune_db_file.fail() || fortune_db_file.bad()) {
-        PLOG_ERROR << format("unable to read {} bytes of STRFILE database {} at offset {}, {}",
+        PLOG_ERROR << format(FMT_STRING("unable to read {} bytes of STRFILE database {} at offset {}, {}"),
                              STRFILE_ENTRY_SIZE,
                              fortune_db_path.string(),
                              file_offset,
@@ -220,7 +222,7 @@ optional<tuple<uint32_t, uint32_t, char>> GetRandomFortuneOffset(const fs::path 
     auto ec = std::error_code{};
     auto fortune_db_file_size = fs::file_size(fortune_db_path, ec);
     if (ec) {
-        PLOG_ERROR << format("error while getting file size of {}, details: {}",
+        PLOG_ERROR << format(FMT_STRING("error while getting file size of {}, details: {}"),
                              fortune_db_path.string(),
                              ec.message());
         return nullopt;
@@ -230,7 +232,7 @@ optional<tuple<uint32_t, uint32_t, char>> GetRandomFortuneOffset(const fs::path 
     fortune_db_file.open(fortune_db_path, ios_base::in | ios_base::binary);
 
     if (!fortune_db_file.is_open() || fortune_db_file.fail() || fortune_db_file.bad()) {
-        PLOG_ERROR << format("unable to open STRFILE database {} for reading, {}",
+        PLOG_ERROR << format(FMT_STRING("unable to open STRFILE database {} for reading, {}"),
                              fortune_db_path.string(),
                              mmotd::error::ios_flags::to_string(fortune_db_file));
         return nullopt;
@@ -239,7 +241,7 @@ optional<tuple<uint32_t, uint32_t, char>> GetRandomFortuneOffset(const fs::path 
     auto strfile_header = StrFileHeader{};
     fortune_db_file.read(reinterpret_cast<char *>(&strfile_header), sizeof(StrFileHeader));
     if (fortune_db_file.fail() || fortune_db_file.bad()) {
-        PLOG_ERROR << format("unable to read STRFILE database header {}, {}",
+        PLOG_ERROR << format(FMT_STRING("unable to read STRFILE database header {}, {}"),
                              fortune_db_path.string(),
                              mmotd::error::ios_flags::to_string(fortune_db_file));
         return nullopt;
@@ -247,22 +249,22 @@ optional<tuple<uint32_t, uint32_t, char>> GetRandomFortuneOffset(const fs::path 
 
     strfile_header.update();
     if (strfile_header.version != STRFILE_VERSION) {
-        PLOG_ERROR << format("STRFILE database header is version {} not the expected version {}",
+        PLOG_ERROR << format(FMT_STRING("STRFILE database header is version {} not the expected version {}"),
                              strfile_header.version,
                              STRFILE_VERSION);
         return nullopt;
     }
 
-    PLOG_VERBOSE << format("sizeof STRFILE header: {}", sizeof(StrFileHeader) + STRFILE_HEADER_PADDING);
+    PLOG_VERBOSE << format(FMT_STRING("sizeof STRFILE header: {}"), sizeof(StrFileHeader) + STRFILE_HEADER_PADDING);
     auto remaining_size = static_cast<size_t>(fortune_db_file_size) - sizeof(StrFileHeader) - STRFILE_ENTRY_SIZE;
-    PLOG_VERBOSE << format("remaining size : {}", remaining_size);
-    PLOG_VERBOSE << format("number of strs : {}", strfile_header.count);
-    PLOG_VERBOSE << format("calculated strs: {} with {} bytes remaining",
+    PLOG_VERBOSE << format(FMT_STRING("remaining size : {}"), remaining_size);
+    PLOG_VERBOSE << format(FMT_STRING("number of strs : {}"), strfile_header.count);
+    PLOG_VERBOSE << format(FMT_STRING("calculated strs: {} with {} bytes remaining"),
                            remaining_size / STRFILE_ENTRY_SIZE,
                            remaining_size % STRFILE_ENTRY_SIZE);
 
     auto random_index = effing_random::get<size_t>(0, static_cast<size_t>(strfile_header.count));
-    PLOG_VERBOSE << format("random STRFILE database index: {}", random_index);
+    PLOG_VERBOSE << format(FMT_STRING("random STRFILE database index: {}"), random_index);
     auto file_offset = ConvertDbIndexToFortuneFileOffset(random_index, fortune_db_file_size);
 
     auto fortune_offset = ReadRandomFortuneOffset(fortune_db_path, fortune_db_file, file_offset);
@@ -279,7 +281,7 @@ optional<string> ReadFortune(const fs::path &fortune_path, uint32_t offset, uint
     fortune_file.open(fortune_path, ios_base::in);
 
     if (!fortune_file.is_open() || fortune_file.fail() || fortune_file.bad()) {
-        PLOG_ERROR << format("unable to open {} for reading, {}",
+        PLOG_ERROR << format(FMT_STRING("unable to open {} for reading, {}"),
                              fortune_path.string(),
                              mmotd::error::ios_flags::to_string(fortune_file));
         return nullopt;
@@ -287,7 +289,7 @@ optional<string> ReadFortune(const fs::path &fortune_path, uint32_t offset, uint
 
     fortune_file.seekg(offset);
     if (!fortune_file.good()) {
-        PLOG_ERROR << format("unable to seek {} to fortune at offset {}, {}",
+        PLOG_ERROR << format(FMT_STRING("unable to seek {} to fortune at offset {}, {}"),
                              fortune_path.string(),
                              offset,
                              mmotd::error::ios_flags::to_string(fortune_file));
@@ -297,7 +299,7 @@ optional<string> ReadFortune(const fs::path &fortune_path, uint32_t offset, uint
     auto buffer = vector<char>(max_size, 0);
     fortune_file.read(buffer.data(), buffer.size());
     if (fortune_file.fail() || fortune_file.bad()) {
-        PLOG_ERROR << format("unable to read {} bytes of the fortune file {} at offset {}, {}",
+        PLOG_ERROR << format(FMT_STRING("unable to read {} bytes of the fortune file {} at offset {}, {}"),
                              max_size,
                              fortune_path.string(),
                              offset,
@@ -310,7 +312,7 @@ optional<string> ReadFortune(const fs::path &fortune_path, uint32_t offset, uint
     if (i != string::npos) {
         fortune = fortune.substr(0, i);
     }
-    PLOG_VERBOSE << format("fortune:\n{}", fortune);
+    PLOG_VERBOSE << format(FMT_STRING("fortune:\n{}"), fortune);
     return make_optional(trim_right_copy(fortune));
 }
 
@@ -331,24 +333,28 @@ optional<string> GetRandomFortune(const string &fortune_name) {
     auto ec = std::error_code{};
     auto fortune_file_size = fs::file_size(fortune_path, ec);
     if (ec) {
-        PLOG_ERROR << format("error while getting file size of {}, details: {}", fortune_path.string(), ec.message());
+        PLOG_ERROR << format(FMT_STRING("error while getting file size of {}, details: {}"),
+                             fortune_path.string(),
+                             ec.message());
         return nullopt;
     }
 
     if (fortune_offset >= fortune_file_size) {
-        PLOG_ERROR << format("the fortune offset={} is beyond the fortune file size={}",
+        PLOG_ERROR << format(FMT_STRING("the fortune offset={} is beyond the fortune file size={}"),
                              fortune_offset,
                              fortune_file_size);
         return nullopt;
     } else if (fortune_offset + max_fortune_size > fortune_file_size) {
         PLOG_DEBUG << format(
-            "updating fortune read size (offset={} + read size={}) since it is now past eof (file size={} bytes)",
+            FMT_STRING(
+                "updating fortune read size (offset={} + read size={}) since it is now past eof (file size={} bytes)"),
             fortune_offset,
             max_fortune_size,
             fortune_file_size);
         max_fortune_size = fortune_file_size - fortune_offset;
         PLOG_DEBUG << format(
-            "updated fortune read size (offset={} + read size={}) should now be to the eof (file size={} bytes)",
+            FMT_STRING(
+                "updated fortune read size (offset={} + read size={}) should now be to the eof (file size={} bytes)"),
             fortune_offset,
             max_fortune_size,
             fortune_file_size);

--- a/lib/src/general.cpp
+++ b/lib/src/general.cpp
@@ -82,7 +82,7 @@ private:
 
 optional<Greeting> Greetings::FindGreeting() const {
     const auto hour = mmotd::chrono::io::get_current_hour();
-    PLOG_VERBOSE << fmt::format("the current hour is {}", hour);
+    PLOG_VERBOSE << fmt::format(FMT_STRING("the current hour is {}"), hour);
 
     if (value_in_range(hour, MORNING_GREETING.begin(), MORNING_GREETING.end())) {
         return MORNING_GREETING;
@@ -93,7 +93,7 @@ optional<Greeting> Greetings::FindGreeting() const {
     } else {
         if (value_in_range(hour, NIGHT_GREETING.end(), NIGHT_GREETING.begin())) {
             // is outside of the night greeting time... should have been picked up by the above
-            PLOG_ERROR << fmt::format("hour value={} did not find it's way into any block of time", hour);
+            PLOG_ERROR << fmt::format(FMT_STRING("hour value={} did not find it's way into any block of time"), hour);
             return nullopt;
         }
         return NIGHT_GREETING;

--- a/lib/src/http_request.cpp
+++ b/lib/src/http_request.cpp
@@ -163,7 +163,7 @@ optional<string> HttpClient::MakeRequestImpl() {
     auto response = Request(*stream);
 
     auto response_str = response.body();
-    PLOG_INFO << format("response from {}:{}{}\n{}", host_, port_, path_, response_str);
+    PLOG_INFO << format(FMT_STRING("response from {}:{}{}\n{}"), host_, port_, path_, response_str);
     CloseStream(*stream);
 
     return make_optional(response_str);
@@ -190,10 +190,10 @@ optional<string> HttpRequest::MakeRequest(string path) {
         return HttpClient{protocol_, host_, port_, path}.MakeRequest();
     } catch (boost::exception &ex) {
         auto diag = boost::diagnostic_information(ex);
-        auto error_str = format("http client threw boost::exception {}", diag);
+        auto error_str = format(FMT_STRING("http client threw boost::exception {}"), diag);
         PLOG_ERROR << error_str;
     } catch (const std::exception &ex) {
-        auto error_str = format("http client threw {}", ex.what());
+        auto error_str = format(FMT_STRING("http client threw {}"), ex.what());
         PLOG_ERROR << error_str;
     }
     return nullopt;

--- a/lib/src/platform/darwin/boot_time.cpp
+++ b/lib/src/platform/darwin/boot_time.cpp
@@ -29,14 +29,15 @@ optional<std::chrono::system_clock::time_point> GetBootTime() {
     if (sysctl(mib, 2, &result, &result_len, NULL, 0) == -1) {
         auto error_str = string{"sysctl(KERN_BOOTTIME) syscall failed"};
         if (auto errno_str = mmotd::error::posix_error::to_string(); !errno_str.empty()) {
-            error_str += format(", details: {}", errno_str);
+            error_str += format(FMT_STRING(", details: {}"), errno_str);
         }
         PLOG_ERROR << error_str;
         return make_optional(std::chrono::system_clock::now());
     }
 
     auto boot_time_point = std::chrono::system_clock::from_time_t(result.tv_sec);
-    PLOG_VERBOSE << format("sysctl(KERN_BOOTTIME): {}", to_string(boot_time_point, "%d-%h-%Y %I:%M:%S%p %Z"));
+    PLOG_VERBOSE << format(FMT_STRING("sysctl(KERN_BOOTTIME): {}"),
+                           to_string(boot_time_point, "%d-%h-%Y %I:%M:%S%p %Z"));
     return make_optional(boot_time_point);
 }
 

--- a/lib/src/platform/darwin/lastlog.cpp
+++ b/lib/src/platform/darwin/lastlog.cpp
@@ -24,12 +24,12 @@ LastLoginDetails GetLastLogDetails() {
 
     auto entries = GetDbEntries<ENTRY_TYPE::User>();
     auto user_info = GetUserInformation();
-    PLOG_VERBOSE << format("last login: entries size: {}, user info: {}",
+    PLOG_VERBOSE << format(FMT_STRING("last login: entries size: {}, user info: {}"),
                            entries.size(),
                            user_info.empty() ? "empty" : user_info.username);
 
     if (entries.empty() || user_info.empty()) {
-        PLOG_ERROR << format("last login: entries size: {}, user info: {}",
+        PLOG_ERROR << format(FMT_STRING("last login: entries size: {}, user info: {}"),
                              entries.size(),
                              user_info.empty() ? "empty" : "valid");
         return LastLoginDetails{};
@@ -44,18 +44,18 @@ LastLoginDetails GetLastLogDetails() {
     }
 
     const auto &entry = *i;
-    PLOG_VERBOSE << format("last log: found {}", entry.to_string());
+    PLOG_VERBOSE << format(FMT_STRING("last log: found {}"), entry.to_string());
 
-    auto summary = format("{} logged into {}", entry.user, entry.device_name);
+    auto summary = format(FMT_STRING("{} logged into {}"), entry.user, entry.device_name);
     if (!entry.hostname.empty()) {
-        summary += format(" from {}", entry.hostname);
+        summary += format(FMT_STRING(" from {}"), entry.hostname);
     }
 
     auto log_in_time = std::chrono::system_clock::from_time_t(entry.seconds);
     auto details = LastLoginDetails{summary, log_in_time, std::chrono::system_clock::time_point{}};
 
-    PLOG_VERBOSE << format("last login: {}", details.summary);
-    PLOG_VERBOSE << format("last log in: {}", to_string(details.log_in, "%d-%h-%Y %I:%M:%S%p %Z"));
+    PLOG_VERBOSE << format(FMT_STRING("last login: {}"), details.summary);
+    PLOG_VERBOSE << format(FMT_STRING("last log in: {}"), to_string(details.log_in, "%d-%h-%Y %I:%M:%S%p %Z"));
     PLOG_VERBOSE << "last log out: still logged in";
 
     return details;

--- a/lib/src/platform/darwin/load_average.cpp
+++ b/lib/src/platform/darwin/load_average.cpp
@@ -21,7 +21,7 @@ optional<int32_t> GetCpuCount() {
         PLOG_ERROR << "sysconf returned -1 calling get processor count _SC_NPROCESSORS_ONLN";
         return nullopt;
     } else {
-        PLOG_INFO << format("sysconf for _SC_NPROCESSORS_ONLN returned {} processors", cpu_count);
+        PLOG_INFO << format(FMT_STRING("sysconf for _SC_NPROCESSORS_ONLN returned {} processors"), cpu_count);
         return make_optional(cpu_count);
     }
 }
@@ -33,7 +33,7 @@ optional<double> GetSystemLoadAverage() {
         PLOG_ERROR << "sysctlbyname returned -1 calling vm.loadavg";
         return nullopt;
     } else {
-        PLOG_INFO << format("sysctlbyname returned 1 min: {}, 5 min: {}, 15 min: {}",
+        PLOG_INFO << format(FMT_STRING("sysctlbyname returned 1 min: {}, 5 min: {}, 15 min: {}"),
                             load.ldavg[0] / static_cast<double>(load.fscale),
                             load.ldavg[1] / static_cast<double>(load.fscale),
                             load.ldavg[2] / static_cast<double>(load.fscale));

--- a/lib/src/platform/darwin/memory.cpp
+++ b/lib/src/platform/darwin/memory.cpp
@@ -35,7 +35,7 @@ bool GetVmStat(vm_statistics_data_t *vmstat) {
 
     auto retval = host_statistics(mach_port, HOST_VM_INFO, reinterpret_cast<host_info_t>(vmstat), &count);
     if (retval != KERN_SUCCESS) {
-        PLOG_ERROR << format("when calling host_statistics, details: {}", mach_error_string(retval));
+        PLOG_ERROR << format(FMT_STRING("when calling host_statistics, details: {}"), mach_error_string(retval));
         return false;
     }
 
@@ -49,7 +49,7 @@ optional<uint64_t> GetTotalMemory() {
     if (sysctl(mib, 2, &total, &len, NULL, 0) == -1) {
         auto error_str = string{"sysctl(HW_MEMSIZE) syscall failed"};
         if (auto errno_str = mmotd::error::posix_error::to_string(); !errno_str.empty()) {
-            error_str += format(", details: {}", errno_str);
+            error_str += format(FMT_STRING(", details: {}"), errno_str);
         }
         PLOG_ERROR << error_str;
         return nullopt;
@@ -71,20 +71,20 @@ optional<mmotd::platform::MemoryDetails> GetMemoryUsage() {
 
     const auto pagesize = getpagesize();
 
-    PLOG_VERBOSE << format("pagesize: {}", pagesize);
-    PLOG_VERBOSE << format("active count: {}, {}",
+    PLOG_VERBOSE << format(FMT_STRING("pagesize: {}"), pagesize);
+    PLOG_VERBOSE << format(FMT_STRING("active count: {}, {}"),
                            to_human_size(vm_statistics_data.active_count),
                            vm_statistics_data.active_count);
-    PLOG_VERBOSE << format("inactive count: {}, {}",
+    PLOG_VERBOSE << format(FMT_STRING("inactive count: {}, {}"),
                            to_human_size(vm_statistics_data.inactive_count),
                            vm_statistics_data.inactive_count);
-    PLOG_VERBOSE << format("wire count: {}, {}",
+    PLOG_VERBOSE << format(FMT_STRING("wire count: {}, {}"),
                            to_human_size(vm_statistics_data.wire_count),
                            vm_statistics_data.wire_count);
-    PLOG_VERBOSE << format("free count: {}, {}",
+    PLOG_VERBOSE << format(FMT_STRING("free count: {}, {}"),
                            to_human_size(vm_statistics_data.free_count),
                            vm_statistics_data.free_count);
-    PLOG_VERBOSE << format("speculative count: {}, {}",
+    PLOG_VERBOSE << format(FMT_STRING("speculative count: {}, {}"),
                            to_human_size(vm_statistics_data.speculative_count),
                            vm_statistics_data.speculative_count);
 
@@ -93,21 +93,21 @@ optional<mmotd::platform::MemoryDetails> GetMemoryUsage() {
     auto wired = static_cast<uint64_t>(vm_statistics_data.wire_count) * pagesize;
     auto free = static_cast<uint64_t>(vm_statistics_data.free_count) * pagesize;
     auto speculative = static_cast<uint64_t>(vm_statistics_data.speculative_count) * pagesize;
-    PLOG_VERBOSE << format("active: {}, {}", to_human_size(active), active);
-    PLOG_VERBOSE << format("inactive: {}, {}", to_human_size(inactive), inactive);
-    PLOG_VERBOSE << format("wired: {}, {}", to_human_size(wired), wired);
-    PLOG_VERBOSE << format("free: {}, {}", to_human_size(free), free);
-    PLOG_VERBOSE << format("speculative: {}, {}", to_human_size(speculative), speculative);
+    PLOG_VERBOSE << format(FMT_STRING("active: {}, {}"), to_human_size(active), active);
+    PLOG_VERBOSE << format(FMT_STRING("inactive: {}, {}"), to_human_size(inactive), inactive);
+    PLOG_VERBOSE << format(FMT_STRING("wired: {}, {}"), to_human_size(wired), wired);
+    PLOG_VERBOSE << format(FMT_STRING("free: {}, {}"), to_human_size(free), free);
+    PLOG_VERBOSE << format(FMT_STRING("speculative: {}, {}"), to_human_size(speculative), speculative);
 
     auto avail = inactive + free;
     auto used = active + wired;
     free = speculative < free ? free - speculative : 0;
-    PLOG_VERBOSE << format("avail = inactive + free: {}, {}", to_human_size(avail), avail);
-    PLOG_VERBOSE << format("used = active + wired: {}, {}", to_human_size(used), used);
-    PLOG_VERBOSE << format("free = free - speculative: {}, {}", to_human_size(free), free);
+    PLOG_VERBOSE << format(FMT_STRING("avail = inactive + free: {}, {}"), to_human_size(avail), avail);
+    PLOG_VERBOSE << format(FMT_STRING("used = active + wired: {}, {}"), to_human_size(used), used);
+    PLOG_VERBOSE << format(FMT_STRING("free = free - speculative: {}, {}"), to_human_size(free), free);
 
     auto percent = (static_cast<double>(total - avail) / static_cast<double>(total)) * 100.0;
-    PLOG_VERBOSE << format("percent used: {:.01f}", percent);
+    PLOG_VERBOSE << format(FMT_STRING("percent used: {:.01f}"), percent);
 
     return make_optional(mmotd::platform::MemoryDetails{total, avail, percent, used, free, active, inactive, wired});
 }

--- a/lib/src/platform/darwin/processes.cpp
+++ b/lib/src/platform/darwin/processes.cpp
@@ -19,10 +19,11 @@ optional<vector<int32_t>> GetProcessesInfo() {
     int mib[3] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL};
     int count = 8; // arbitrary count
     for (int index = 0; index < count; ++index) {
-        PLOG_VERBOSE << format("{}. attempting to get process list", index);
+        PLOG_VERBOSE << format(FMT_STRING("{}. attempting to get process list"), index);
         auto size = size_t{0};
         if (sysctl(mib, 3, NULL, &size, NULL, 0) == -1) {
-            PLOG_ERROR << format("sysctl(KERN_PROC_ALL) failed, details: {}", mmotd::error::posix_error::to_string());
+            PLOG_ERROR << format(FMT_STRING("sysctl(KERN_PROC_ALL) failed, details: {}"),
+                                 mmotd::error::posix_error::to_string());
             break;
         }
 
@@ -30,18 +31,20 @@ optional<vector<int32_t>> GetProcessesInfo() {
         auto buffer = vector<uint8_t>(size, 0);
         if (sysctl(mib, 3, buffer.data(), &size, NULL, 0) == -1) {
             if (errno == ENOMEM) {
-                PLOG_ERROR << format("sysctl(KERN_PROC_ALL) failed with ENOMEM, attempting allocation again");
+                PLOG_ERROR << format(
+                    FMT_STRING("sysctl(KERN_PROC_ALL) failed with ENOMEM, attempting allocation again"));
                 continue;
             }
-            PLOG_ERROR << format("sysctl(KERN_PROC_ALL) failed, details: {}", mmotd::error::posix_error::to_string());
+            PLOG_ERROR << format(FMT_STRING("sysctl(KERN_PROC_ALL) failed, details: {}"),
+                                 mmotd::error::posix_error::to_string());
             break;
         }
 
         const kinfo_proc *proc_list = reinterpret_cast<const kinfo_proc *>(buffer.data());
         auto proc_count = static_cast<size_t>(size / sizeof(kinfo_proc));
-        PLOG_INFO << format("sysctl(KERN_PROC_ALL) discovered {} processes", proc_count);
+        PLOG_INFO << format(FMT_STRING("sysctl(KERN_PROC_ALL) discovered {} processes"), proc_count);
         if (proc_count == 0) {
-            PLOG_ERROR << format("sysctl(KERN_PROC_ALL) no PID's were returned");
+            PLOG_ERROR << format(FMT_STRING("sysctl(KERN_PROC_ALL) no PID's were returned"));
             break;
         }
 
@@ -67,9 +70,9 @@ optional<size_t> GetProcessCount() {
     }
     //auto process_ids_str = string{};
     //for (const auto id : process_ids) {
-    //    process_ids_str += format("{}{}", process_ids_str.empty() ? "" : ", ", id);
+    //    process_ids_str += format(FMT_STRING("{}{}", process_ids_str.empty() ? "" : ", "), id);
     //}
-    //PLOG_VERBOSE << format("found process ids: {}", process_ids_str);
+    //PLOG_VERBOSE << format(FMT_STRING("found process ids: {}"), process_ids_str);
     return make_optional((*process_ids).size());
 }
 

--- a/lib/src/platform/darwin/swap.cpp
+++ b/lib/src/platform/darwin/swap.cpp
@@ -26,7 +26,7 @@ optional<SwapDetails> GetSwapMemoryUsage() {
     if (sysctl(mib, 2, &swap_usage, &size, NULL, 0) == -1) {
         auto error_str = string{"sysctl(VM_SWAPUSAGE) syscall failed"};
         if (auto errno_str = mmotd::error::posix_error::to_string(); !errno_str.empty()) {
-            error_str += format(", details: {}", errno_str);
+            error_str += format(FMT_STRING(", details: {}"), errno_str);
         }
         PLOG_ERROR << error_str;
         return nullopt;
@@ -42,10 +42,14 @@ optional<SwapDetails> GetSwapMemoryUsage() {
     auto swap_details =
         SwapDetails{swap_usage.xsu_total, swap_usage.xsu_avail, percent_used, swap_usage.xsu_encrypted != 0};
 
-    PLOG_VERBOSE << format("swap memory total: {}, {} bytes", to_human_size(swap_details.total), swap_details.total);
-    PLOG_VERBOSE << format("swap memory free: {}, {} bytes", to_human_size(swap_details.free), swap_details.free);
-    PLOG_VERBOSE << format("swap memory percent used: {:.02f}", swap_details.percent_used);
-    PLOG_VERBOSE << format("swap memory encrypted: {}", swap_details.encrypted);
+    PLOG_VERBOSE << format(FMT_STRING("swap memory total: {}, {} bytes"),
+                           to_human_size(swap_details.total),
+                           swap_details.total);
+    PLOG_VERBOSE << format(FMT_STRING("swap memory free: {}, {} bytes"),
+                           to_human_size(swap_details.free),
+                           swap_details.free);
+    PLOG_VERBOSE << format(FMT_STRING("swap memory percent used: {:.02f}"), swap_details.percent_used);
+    PLOG_VERBOSE << format(FMT_STRING("swap memory encrypted: {}"), swap_details.encrypted);
 
     return make_optional(swap_details);
 }

--- a/lib/src/platform/darwin/system_information.cpp
+++ b/lib/src/platform/darwin/system_information.cpp
@@ -61,7 +61,7 @@ string GetPlatformNameVersion(int major, int minor) {
     auto platform_name = GetPlatformIdentifier(major, minor, PLATFORM_NAMES);
     auto version_name = GetPlatformIdentifier(major, minor, VERSION_NAMES);
 
-    return format("{} {}", platform_name, version_name);
+    return format(FMT_STRING("{} {}"), platform_name, version_name);
 }
 
 optional<tuple<int, int, int>> GetOsVersion() {
@@ -69,7 +69,8 @@ optional<tuple<int, int, int>> GetOsVersion() {
     size_t miblen = 512;
     if (sysctlnametomib("kern.osproductversion", mib, &miblen) == -1) {
         auto error_str = mmotd::error::posix_error::to_string();
-        PLOG_ERROR << format("error calling sysctlnametomib with kern.osproductversion, details: {}", error_str);
+        PLOG_ERROR << format(FMT_STRING("error calling sysctlnametomib with kern.osproductversion, details: {}"),
+                             error_str);
         return nullopt;
     }
     char version[512] = {0};
@@ -77,7 +78,7 @@ optional<tuple<int, int, int>> GetOsVersion() {
     size_t length = sizeof(long long);
     if (sysctl(mib, 2, version, &length, NULL, 0) == -1) {
         auto error_str = mmotd::error::posix_error::to_string();
-        PLOG_ERROR << format("error calling sysctl with kern.osproductversion, details: {}", error_str);
+        PLOG_ERROR << format(FMT_STRING("error calling sysctl with kern.osproductversion, details: {}"), error_str);
         return nullopt;
     }
     auto versions = vector<string>{};
@@ -98,9 +99,9 @@ optional<tuple<int, int, int>> GetOsVersion() {
 optional<KernelDetails> GetKernelDetails() {
     struct utsname buf = {};
     int retval = uname(&buf);
-    PLOG_DEBUG << format("uname returned {} [{}]", retval, retval == 0 ? "success" : "failed");
+    PLOG_DEBUG << format(FMT_STRING("uname returned {} [{}]"), retval, retval == 0 ? "success" : "failed");
     if (retval != 0) {
-        PLOG_ERROR << format("uname failed with return code '{}'", retval);
+        PLOG_ERROR << format(FMT_STRING("uname failed with return code '{}'"), retval);
         return nullopt;
     }
 
@@ -145,7 +146,7 @@ SystemDetails GetSystemInformationDetails() {
     }
 
     auto [major, minor, patch] = *os_version_holder;
-    details.platform_version = format("{}.{}.{}", major, minor, patch);
+    details.platform_version = format(FMT_STRING("{}.{}.{}"), major, minor, patch);
     details.platform_name = GetPlatformNameVersion(major, minor);
 
     return details;

--- a/lib/src/platform/darwin/user_accounting_database.cpp
+++ b/lib/src/platform/darwin/user_accounting_database.cpp
@@ -43,16 +43,19 @@ DbEntries GetUserAccountEntriesImpl() {
     auto i = size_t{0};
     for (const utmpx *utmpx_ptr = getutxent(); utmpx_ptr != nullptr; utmpx_ptr = getutxent(), ++i) {
         auto ut_type_str = DbEntry::entry_type_to_string(utmpx_ptr->ut_type);
-        PLOG_VERBOSE << format("iteration #{}, type: {}, utmpx *: {}", i + 1, ut_type_str, fmt::ptr(utmpx_ptr));
+        PLOG_VERBOSE << format(FMT_STRING("iteration #{}, type: {}, utmpx *: {}"),
+                               i + 1,
+                               ut_type_str,
+                               fmt::ptr(utmpx_ptr));
 
         auto entry = DbEntry::from_utmpx(*utmpx_ptr);
         if (!entry.empty()) {
             entries.push_back(entry);
-            PLOG_VERBOSE << format("adding user account entry #{}", entries.size());
+            PLOG_VERBOSE << format(FMT_STRING("adding user account entry #{}"), entries.size());
         }
     }
 
-    PLOG_VERBOSE << format("returning {} user account entries", entries.size());
+    PLOG_VERBOSE << format(FMT_STRING("returning {} user account entries"), entries.size());
     return entries;
 }
 
@@ -68,11 +71,12 @@ UserInformation GetUserInformationImpl() {
     auto user_id = geteuid();
     auto retval = getpwuid_r(user_id, &pwd, buf.data(), buf.size(), &pwd_ptr);
     if (pwd_ptr == nullptr && retval == 0) {
-        PLOG_ERROR << format("getpwnam_r for user id {} did not return a pwd structure or an error code", user_id);
+        PLOG_ERROR << format(FMT_STRING("getpwnam_r for user id {} did not return a pwd structure or an error code"),
+                             user_id);
         return UserInformation{};
     } else if (pwd_ptr == nullptr && retval != 0) {
         auto error_str = pe::to_string(retval);
-        PLOG_ERROR << format("getpwnam_r for user id {} failed, {}", user_id, error_str);
+        PLOG_ERROR << format(FMT_STRING("getpwnam_r for user id {} failed, {}"), user_id, error_str);
         return UserInformation{};
     }
     return UserInformation::from_passwd(pwd);
@@ -85,7 +89,7 @@ namespace mmotd::platform::user_account_database {
 string DbEntry::to_string() const {
     auto time_point = std::chrono::system_clock::from_time_t(seconds);
     auto time_str = mmotd::chrono::io::to_string(time_point, "%d-%h-%Y %I:%M%p %Z");
-    return format("user: {}, device: {}, hostname: {}, time: {}, ip: {}, type: {}",
+    return format(FMT_STRING("user: {}, device: {}, hostname: {}, time: {}, ip: {}, type: {}"),
                   user,
                   device_name,
                   hostname,
@@ -103,14 +107,14 @@ DbEntry DbEntry::from_utmpx(const utmpx &db) {
     auto username = strlen(db.ut_user) > 0 ? string{db.ut_user} : string{};
     auto hostname = strlen(db.ut_host) > 0 ? string{db.ut_host} : string{};
 
-    PLOG_VERBOSE << format("utmpx id: {}", string(db.ut_id, db.ut_id + 4));
+    PLOG_VERBOSE << format(FMT_STRING("utmpx id: {}"), string(db.ut_id, db.ut_id + 4));
     auto entry = DbEntry{static_cast<ENTRY_TYPE>(db.ut_type),
                          device_name,
                          username,
                          hostname,
                          db.ut_tv.tv_sec,
                          boost::asio::ip::address{}};
-    PLOG_VERBOSE << format("parsed entry: {}", entry.to_string());
+    PLOG_VERBOSE << format(FMT_STRING("parsed entry: {}"), entry.to_string());
     return entry;
 }
 

--- a/lib/src/platform/linux/boot_time.cpp
+++ b/lib/src/platform/linux/boot_time.cpp
@@ -25,7 +25,7 @@ optional<std::chrono::system_clock::time_point> GetBootTime() {
     uptime_file.open(UPTIME_FILENAME, ios_base::in);
 
     if (!uptime_file.is_open() || uptime_file.fail() || uptime_file.bad()) {
-        PLOG_ERROR << format("unable to open {} for reading, {}",
+        PLOG_ERROR << format(FMT_STRING("unable to open {} for reading, {}"),
                              UPTIME_FILENAME,
                              mmotd::error::ios_flags::to_string(uptime_file));
         return make_optional(std::chrono::system_clock::now());

--- a/lib/src/platform/linux/lastlog.cpp
+++ b/lib/src/platform/linux/lastlog.cpp
@@ -25,12 +25,12 @@ LastLoginDetails GetLastLogDetails() {
 
     auto entries = GetDbEntries<ENTRY_TYPE::User>();
     auto user_info = GetUserInformation();
-    PLOG_VERBOSE << format("last login: entries size: {}, user info: {}",
+    PLOG_VERBOSE << format(FMT_STRING("last login: entries size: {}, user info: {}"),
                            entries.size(),
                            user_info.empty() ? "empty" : user_info.username);
 
     if (entries.empty() || user_info.empty()) {
-        PLOG_ERROR << format("last login: entries size: {}, user info: {}",
+        PLOG_ERROR << format(FMT_STRING("last login: entries size: {}, user info: {}"),
                              entries.size(),
                              user_info.empty() ? "empty" : "valid");
         return LastLoginDetails{};
@@ -45,18 +45,18 @@ LastLoginDetails GetLastLogDetails() {
     }
 
     const auto &entry = *i;
-    PLOG_VERBOSE << format("last log: found {}", entry.to_string());
+    PLOG_VERBOSE << format(FMT_STRING("last log: found {}"), entry.to_string());
 
-    auto summary = format("{} logged into {}", entry.user, entry.device_name);
+    auto summary = format(FMT_STRING("{} logged into {}"), entry.user, entry.device_name);
     if (!entry.hostname.empty()) {
-        summary += format(" from {}", entry.hostname);
+        summary += format(FMT_STRING(" from {}"), entry.hostname);
     }
 
     auto log_in_time = std::chrono::system_clock::from_time_t(entry.seconds);
     auto details = LastLoginDetails{summary, log_in_time, std::chrono::system_clock::time_point{}};
 
-    PLOG_VERBOSE << format("last login: {}", details.summary);
-    PLOG_VERBOSE << format("last log in: {}", to_string(details.log_in, "%d-%h-%Y %I:%M:%S%p %Z"));
+    PLOG_VERBOSE << format(FMT_STRING("last login: {}"), details.summary);
+    PLOG_VERBOSE << format(FMT_STRING("last log in: {}"), to_string(details.log_in, "%d-%h-%Y %I:%M:%S%p %Z"));
     PLOG_VERBOSE << "last log out: still logged in";
 
     return details;

--- a/lib/src/platform/linux/load_average.cpp
+++ b/lib/src/platform/linux/load_average.cpp
@@ -28,7 +28,7 @@ optional<int32_t> GetCpuCount() {
         PLOG_ERROR << "sysconf returned -1 calling get processor count _SC_NPROCESSORS_ONLN";
         return nullopt;
     } else {
-        PLOG_INFO << format("sysconf for _SC_NPROCESSORS_ONLN returned {} processors", cpu_count);
+        PLOG_INFO << format(FMT_STRING("sysconf for _SC_NPROCESSORS_ONLN returned {} processors"), cpu_count);
         return make_optional(cpu_count);
     }
 }
@@ -38,11 +38,11 @@ optional<double> FromString(string str) {
         auto value = stod(str, nullptr);
         return make_optional(value);
     } catch (const std::invalid_argument &ex) {
-        PLOG_ERROR << format("unable to convert {} to double: {}", str, ex.what());
+        PLOG_ERROR << format(FMT_STRING("unable to convert {} to double: {}"), str, ex.what());
     } catch (const std::out_of_range &ex) {
-        PLOG_ERROR << format("unable to convert {} to double: {}", str, ex.what());
+        PLOG_ERROR << format(FMT_STRING("unable to convert {} to double: {}"), str, ex.what());
     } catch (const std::exception &ex) {
-        PLOG_ERROR << format("unable to convert {} to double: {}.  RETHROWING", str, ex.what());
+        PLOG_ERROR << format(FMT_STRING("unable to convert {} to double: {}.  RETHROWING"), str, ex.what());
         throw;
     }
     return nullopt;
@@ -52,7 +52,7 @@ optional<double> ParseLoadAverage(const string &line) {
     auto parts = vector<string>{};
     boost::split(parts, line, boost::is_any_of(" "), boost::token_compress_on);
     if (parts.size() < 2) {
-        PLOG_ERROR << format("unable to parse '{}' into valid load averages", line);
+        PLOG_ERROR << format(FMT_STRING("unable to parse '{}' into valid load averages"), line);
         return nullopt;
     }
     return FromString(boost::trim_copy(parts.front()));
@@ -64,7 +64,7 @@ optional<double> GetSystemLoadAverage() {
     load_average_file.open(LOAD_AVERAGE_FILENAME, ios_base::in);
 
     if (!load_average_file.is_open() || load_average_file.fail() || load_average_file.bad()) {
-        PLOG_ERROR << format("unable to open {} for reading, {}",
+        PLOG_ERROR << format(FMT_STRING("unable to open {} for reading, {}"),
                              LOAD_AVERAGE_FILENAME,
                              mmotd::error::ios_flags::to_string(load_average_file));
         return nullopt;

--- a/lib/src/platform/linux/memory.cpp
+++ b/lib/src/platform/linux/memory.cpp
@@ -25,32 +25,32 @@ optional<mmotd::platform::MemoryDetails> GetMemoryUsage() {
     struct sysinfo info {};
     if (sysinfo(&info) == -1) {
         auto error_str = mmotd::error::posix_error::to_string();
-        PLOG_ERROR << format("error calling sysinfo, {}", error_str);
+        PLOG_ERROR << format(FMT_STRING("error calling sysinfo, {}"), error_str);
         return nullopt;
     }
 
     auto total = uint64_t{info.totalram} * info.mem_unit;
-    PLOG_VERBOSE << format("memory total ram: {}, {} bytes", to_human_size(total), total);
+    PLOG_VERBOSE << format(FMT_STRING("memory total ram: {}, {} bytes"), to_human_size(total), total);
     auto total_high = uint64_t{info.totalhigh} * info.mem_unit;
-    PLOG_VERBOSE << format("memory total high ram: {}, {} bytes", to_human_size(total_high), total_high);
+    PLOG_VERBOSE << format(FMT_STRING("memory total high ram: {}, {} bytes"), to_human_size(total_high), total_high);
     if (total_high != 0) {
         total = (total_high << 32) | total;
     }
 
     auto free = uint64_t{info.freeram} * info.mem_unit;
-    PLOG_VERBOSE << format("memory free ram: {}, {} bytes", to_human_size(free), free);
+    PLOG_VERBOSE << format(FMT_STRING("memory free ram: {}, {} bytes"), to_human_size(free), free);
     auto free_high = uint64_t{info.freehigh} * info.mem_unit;
-    PLOG_VERBOSE << format("memory free high ram: {}, {} bytes", to_human_size(free_high), free_high);
+    PLOG_VERBOSE << format(FMT_STRING("memory free high ram: {}, {} bytes"), to_human_size(free_high), free_high);
     if (free_high != 0) {
         free = (free_high << 32) | free;
     }
 
-    PLOG_VERBOSE << format("memory total: {}, {} bytes", to_human_size(total), total);
-    PLOG_VERBOSE << format("memory free: {}, {} bytes", to_human_size(free), free);
+    PLOG_VERBOSE << format(FMT_STRING("memory total: {}, {} bytes"), to_human_size(total), total);
+    PLOG_VERBOSE << format(FMT_STRING("memory free: {}, {} bytes"), to_human_size(free), free);
     auto percent_used = 0.0;
     if (total != 0) {
         percent_used = (static_cast<double>(total - free) / static_cast<double>(total)) * 100.0;
-        PLOG_VERBOSE << format("percent used: {:.01f}", percent_used);
+        PLOG_VERBOSE << format(FMT_STRING("percent used: {:.01f}"), percent_used);
     }
 
     auto memory_details = mmotd::platform::MemoryDetails{};

--- a/lib/src/platform/linux/processes.cpp
+++ b/lib/src/platform/linux/processes.cpp
@@ -28,27 +28,31 @@ vector<string> GetProcessDirectories() {
     //auto flags = fs::directory_options::skip_permission_denied;
     for (auto &dir_entry : fs::directory_iterator(PROC_DIRECTORY, ec /*, flags*/)) {
         if (ec) {
-            PLOG_ERROR << format("error encountered while iterating {} directory, {}", PROC_DIRECTORY, ec.message());
+            PLOG_ERROR << format(FMT_STRING("error encountered while iterating {} directory, {}"),
+                                 PROC_DIRECTORY,
+                                 ec.message());
             return vector<string>{};
         }
 
         auto path_entry = dir_entry.path();
         if (!dir_entry.is_directory()) {
-            //PLOG_DEBUG << format("ignoring {} since it is not a directory", path_entry.string());
+            //PLOG_DEBUG << format(FMT_STRING("ignoring {} since it is not a directory"), path_entry.string());
             continue;
         }
 
         const auto &name = path_entry.stem().string();
         if (!all_of(begin(name), end(name), boost::is_digit())) {
-            //PLOG_DEBUG << format("ignoring {} since it is not all digits", path_entry.string());
+            //PLOG_DEBUG << format(FMT_STRING("ignoring {} since it is not all digits"), path_entry.string());
             continue;
         }
-        //PLOG_DEBUG << format("adding process directory {}", path_entry.string());
+        //PLOG_DEBUG << format(FMT_STRING("adding process directory {}"), path_entry.string());
         process_subdirs.push_back(path_entry.string());
     }
 
     if (ec) {
-        PLOG_ERROR << format("error encountered while iterating {} directory, {}", PROC_DIRECTORY, ec.message());
+        PLOG_ERROR << format(FMT_STRING("error encountered while iterating {} directory, {}"),
+                             PROC_DIRECTORY,
+                             ec.message());
         return vector<string>{};
     }
 

--- a/lib/src/platform/linux/swap.cpp
+++ b/lib/src/platform/linux/swap.cpp
@@ -42,7 +42,7 @@ optional<SwapDetails> GetSwapMemoryUsage() {
     struct sysinfo info {};
     if (sysinfo(&info) == -1) {
         auto error_str = mmotd::error::posix_error::to_string();
-        PLOG_ERROR << format("error calling sysinfo, {}", error_str);
+        PLOG_ERROR << format(FMT_STRING("error calling sysinfo, {}"), error_str);
         return nullopt;
     }
 
@@ -55,10 +55,14 @@ optional<SwapDetails> GetSwapMemoryUsage() {
 
     auto swap_details = SwapDetails{total, free, percent_used, false};
 
-    PLOG_VERBOSE << format("swap memory total: {}, {} bytes", to_human_size(swap_details.total), swap_details.total);
-    PLOG_VERBOSE << format("swap memory free: {}, {} bytes", to_human_size(swap_details.free), swap_details.free);
-    PLOG_VERBOSE << format("swap memory percent used: {:.02f}", swap_details.percent_used);
-    PLOG_VERBOSE << format("swap memory encrypted: {}", swap_details.encrypted);
+    PLOG_VERBOSE << format(FMT_STRING("swap memory total: {}, {} bytes"),
+                           to_human_size(swap_details.total),
+                           swap_details.total);
+    PLOG_VERBOSE << format(FMT_STRING("swap memory free: {}, {} bytes"),
+                           to_human_size(swap_details.free),
+                           swap_details.free);
+    PLOG_VERBOSE << format(FMT_STRING("swap memory percent used: {:.02f}"), swap_details.percent_used);
+    PLOG_VERBOSE << format(FMT_STRING("swap memory encrypted: {}"), swap_details.encrypted);
 
     return make_optional(swap_details);
 }

--- a/lib/src/platform/linux/system_information.cpp
+++ b/lib/src/platform/linux/system_information.cpp
@@ -29,7 +29,7 @@ optional<mmotd::system::KernelDetails> GetKernelDetails() {
     auto retval = uname(&buf);
     if (retval != 0) {
         auto error_str = mmotd::error::posix_error::to_string();
-        PLOG_ERROR << format("error calling uname, {}", error_str);
+        PLOG_ERROR << format(FMT_STRING("error calling uname, {}"), error_str);
         return nullopt;
     }
 
@@ -63,7 +63,7 @@ constexpr static const char *OS_RELEASE = "/etc/os-release";
 vector<string> GetOsVersionFile() {
     auto os_release_path = fs::path(OS_RELEASE);
     if (!fs::is_regular_file(os_release_path) || !fs::is_symlink(os_release_path)) {
-        PLOG_ERROR << format("{} release file does not exist", OS_RELEASE);
+        PLOG_ERROR << format(FMT_STRING("{} release file does not exist"), OS_RELEASE);
         return vector<string>{};
     }
 
@@ -72,7 +72,7 @@ vector<string> GetOsVersionFile() {
     ifs.open(os_release_path, ios_base::in);
     if (!ifs.is_open() || ifs.fail() || ifs.bad()) {
         auto ifs_err = mmotd::error::ios_flags::to_string(ifs);
-        PLOG_ERROR << format("unable to open {}, {}", OS_RELEASE, ifs_err);
+        PLOG_ERROR << format(FMT_STRING("unable to open {}, {}"), OS_RELEASE, ifs_err);
         return vector<string>{};
     }
 
@@ -80,7 +80,7 @@ vector<string> GetOsVersionFile() {
     for (string version_line; getline(ifs, version_line);) {
         if (ifs.fail() || ifs.bad()) {
             auto ifs_err = mmotd::error::ios_flags::to_string(ifs);
-            PLOG_ERROR << format("error reading {}, {}", OS_RELEASE, ifs_err);
+            PLOG_ERROR << format(FMT_STRING("error reading {}, {}"), OS_RELEASE, ifs_err);
             return vector<string>{};
         }
         version_lines.push_back(version_line);
@@ -99,11 +99,11 @@ optional<int> ParseIndividualOsVersion(const string &version_str) {
 
     if (i != end(updated_version_str)) {
         auto offset = std::distance(begin(updated_version_str), i);
-        PLOG_DEBUG << format("found integer offset for {} to be {}", updated_version_str, offset);
+        PLOG_DEBUG << format(FMT_STRING("found integer offset for {} to be {}"), updated_version_str, offset);
         updated_version_str = updated_version_str.substr(offset);
     }
     if (updated_version_str.empty()) {
-        PLOG_DEBUG << format("stripped front of version string {} and now it's empty", version_str);
+        PLOG_DEBUG << format(FMT_STRING("stripped front of version string {} and now it's empty"), version_str);
         return nullopt;
     }
 
@@ -113,15 +113,15 @@ optional<int> ParseIndividualOsVersion(const string &version_str) {
 
     if (j != end(updated_version_str)) {
         auto offset = std::distance(begin(updated_version_str), j);
-        PLOG_DEBUG << format("found integer offset for {} to be {}", updated_version_str, offset);
+        PLOG_DEBUG << format(FMT_STRING("found integer offset for {} to be {}"), updated_version_str, offset);
         updated_version_str = updated_version_str.substr(0, offset);
     }
     if (updated_version_str.empty()) {
-        PLOG_DEBUG << format("stripped back of version string {} and now it's empty", version_str);
+        PLOG_DEBUG << format(FMT_STRING("stripped back of version string {} and now it's empty"), version_str);
         return nullopt;
     }
 
-    PLOG_DEBUG << format("stripped version string is {}", updated_version_str);
+    PLOG_DEBUG << format(FMT_STRING("stripped version string is {}"), updated_version_str);
 
     return make_optional(std::stoi(updated_version_str));
 }
@@ -130,7 +130,7 @@ optional<tuple<int, int, int>> ParseOsVersion(const string &version_str) {
     auto version_numbers = vector<string>{};
     boost::split(version_numbers, version_str, boost::is_any_of("."), boost::token_compress_on);
     if (version_numbers.size() < 2) {
-        PLOG_ERROR << format("unable to split '{}' into a version string", version_str);
+        PLOG_ERROR << format(FMT_STRING("unable to split '{}' into a version string"), version_str);
         return nullopt;
     }
     int major, minor, patch = 0;
@@ -203,7 +203,7 @@ optional<tuple<string, int, int, int>> GetOsVersion() {
             codename = ParseCodename(string{i.end(), file_line.end()});
         }
     }
-    return make_optional(make_tuple(format("{} {}", name, codename), major, minor, patch));
+    return make_optional(make_tuple(format(FMT_STRING("{} {}"), name, codename), major, minor, patch));
 }
 
 } // namespace
@@ -232,7 +232,7 @@ SystemDetails GetSystemInformationDetails() {
     details.byte_order = mmotd::system::to_string(kernel_details.endian);
 
     auto [platform_name, major, minor, patch] = *os_version_holder;
-    details.platform_version = format("{}.{:02}.{}", major, minor, patch);
+    details.platform_version = format(FMT_STRING("{}.{:02}.{}"), major, minor, patch);
     details.platform_name = platform_name;
 
     return details;

--- a/lib/src/platform/linux/user_accounting_database.cpp
+++ b/lib/src/platform/linux/user_accounting_database.cpp
@@ -42,8 +42,9 @@ DbEntries GetUserAccountEntriesImpl() {
     auto retval = getutent_r(&utmp_buf, &utmp_ptr);
     if (retval != 0 || utmp_ptr == nullptr) {
         auto error_str = retval != 0 ? pe::to_string(retval) : pe::to_string();
-        PLOG_ERROR << format("attempting to read first value in user accounting database (utmp) and failed, {}",
-                             error_str);
+        PLOG_ERROR << format(
+            FMT_STRING("attempting to read first value in user accounting database (utmp) and failed, {}"),
+            error_str);
         return DbEntries{};
     }
 
@@ -54,12 +55,15 @@ DbEntries GetUserAccountEntriesImpl() {
     size_t i = 0;
     while (utmp_ptr != nullptr) {
         auto ut_type_str = DbEntry::entry_type_to_string(utmp_ptr->ut_type);
-        PLOG_VERBOSE << format("iteration #{}, type: {}, utmpx *: {}", ++i, ut_type_str, fmt::ptr(utmp_ptr));
+        PLOG_VERBOSE << format(FMT_STRING("iteration #{}, type: {}, utmpx *: {}"),
+                               ++i,
+                               ut_type_str,
+                               fmt::ptr(utmp_ptr));
 
         auto entry = DbEntry::from_utmp(*utmp_ptr);
         if (!entry.empty()) {
             user_account_entries.push_back(entry);
-            PLOG_VERBOSE << format("adding user account entry #{}", user_account_entries.size());
+            PLOG_VERBOSE << format(FMT_STRING("adding user account entry #{}"), user_account_entries.size());
         }
 
         // read the next entry from the database
@@ -70,15 +74,16 @@ DbEntries GetUserAccountEntriesImpl() {
             auto error_value = errno;
             auto error_str = pe::to_string(error_value);
             if (error_value == ENOENT) {
-                PLOG_VERBOSE << format("found the end of user accounting database (utmp), {}", error_str);
+                PLOG_VERBOSE << format(FMT_STRING("found the end of user accounting database (utmp), {}"), error_str);
             } else {
-                PLOG_ERROR << format("attempting to read next value in user accounting database (utmp) and failed, {}",
-                                     error_str);
+                PLOG_ERROR << format(
+                    FMT_STRING("attempting to read next value in user accounting database (utmp) and failed, {}"),
+                    error_str);
             }
             utmp_ptr = nullptr;
         }
     }
-    PLOG_VERBOSE << format("returning {} user account entries", user_account_entries.size());
+    PLOG_VERBOSE << format(FMT_STRING("returning {} user account entries"), user_account_entries.size());
     return user_account_entries;
 }
 
@@ -94,11 +99,12 @@ UserInformation GetUserInformationImpl() {
     auto user_id = geteuid();
     auto retval = getpwuid_r(user_id, &pwd, buf.data(), buf.size(), &pwd_ptr);
     if (pwd_ptr == nullptr && retval == 0) {
-        PLOG_ERROR << format("getpwnam_r for user id {} did not return a pwd structure or an error code", user_id);
+        PLOG_ERROR << format(FMT_STRING("getpwnam_r for user id {} did not return a pwd structure or an error code"),
+                             user_id);
         return UserInformation{};
     } else if (pwd_ptr == nullptr && retval != 0) {
         auto error_str = pe::to_string(retval);
-        PLOG_ERROR << format("getpwnam_r for user id {} failed, {}", user_id, error_str);
+        PLOG_ERROR << format(FMT_STRING("getpwnam_r for user id {} failed, {}"), user_id, error_str);
         return UserInformation{};
     }
     return UserInformation::from_passwd(pwd);
@@ -111,7 +117,7 @@ namespace mmotd::platform::user_account_database {
 string DbEntry::to_string() const {
     auto time_point = std::chrono::system_clock::from_time_t(seconds);
     auto time_str = mmotd::chrono::io::to_string(time_point, "%d-%h-%Y %I:%M%p %Z");
-    return format("user: {}, device: {}, hostname: {}, time: {}, ip: {}, type: {}",
+    return format(FMT_STRING("user: {}, device: {}, hostname: {}, time: {}, ip: {}, type: {}"),
                   user,
                   device_name,
                   hostname,
@@ -137,7 +143,7 @@ DbEntry DbEntry::from_utmp(const utmp &db) {
         ip = ip_address{};
     }
     auto entry = DbEntry{static_cast<ENTRY_TYPE>(db.ut_type), device_name, username, hostname, db.ut_tv.tv_sec, ip};
-    PLOG_VERBOSE << format("parsed entry: {}", entry.to_string());
+    PLOG_VERBOSE << format(FMT_STRING("parsed entry: {}"), entry.to_string());
     return entry;
 }
 

--- a/lib/src/platform/windows/boot_time.cpp
+++ b/lib/src/platform/windows/boot_time.cpp
@@ -26,7 +26,7 @@ optional<string> GetBootTime() {
     //if (sysctl(mib, 2, &result, &result_len, NULL, 0) == -1) {
     //    auto error_str = string{"sysctl(KERN_BOOTTIME) syscall failed"};
     //    if (auto errno_str = mmotd::error::posix_error::to_string(); !errno_str.empty()) {
-    //        error_str += format(", details: {}", errno_str);
+    //        error_str += format(FMT_STRING(", details: {}"), errno_str);
     //    }
     //    PLOG_ERROR << error_str;
     //    return nullopt;

--- a/lib/src/system_details.cpp
+++ b/lib/src/system_details.cpp
@@ -46,7 +46,7 @@ string KernelRelease::to_string() const {
         return str;
     }
     if (build) {
-        str += format("{}{}", (build.value()[0] == '-' ? "" : "."), build.value());
+        str += format(FMT_STRING("{}{}"), (build.value()[0] == '-' ? "" : "."), build.value());
     } else {
         return str;
     }
@@ -139,7 +139,8 @@ KernelRelease KernelRelease::from_string(const string &release) {
         release_parts.push_back(part);
     }
     if (release_parts.size() < 2) {
-        auto error_str = format("uname release string is not of the format 'xx.yy' instead it is '{}'", release);
+        auto error_str =
+            format(FMT_STRING("uname release string is not of the format 'xx.yy' instead it is '{}'"), release);
         MMOTD_THROW_RUNTIME_ERROR(error_str);
     }
     auto kernel_release = KernelRelease{};

--- a/lib/src/users_logged_in.cpp
+++ b/lib/src/users_logged_in.cpp
@@ -38,7 +38,7 @@ string UsersLoggedIn::GetUsersLoggedIn() {
     auto user_information = GetUserInformation();
     auto user_account_enteries = GetDbEntries<ENTRY_TYPE::User>();
     if (user_information.empty() || user_account_enteries.empty()) {
-        PLOG_ERROR << format("user information empty: {}, user account entry size: {}",
+        PLOG_ERROR << format(FMT_STRING("user information empty: {}, user account entry size: {}"),
                              user_information.empty(),
                              user_account_enteries.size());
         // should never happen
@@ -60,15 +60,18 @@ string UsersLoggedIn::GetUsersLoggedIn() {
                                });
 
     if (user_count == 0 || user_account_entry_ptr == nullptr) {
-        PLOG_ERROR << format("user count: {}, user account ptr: {}", user_count, fmt::ptr(user_account_entry_ptr));
+        PLOG_ERROR << format(FMT_STRING("user count: {}, user account ptr: {}"),
+                             user_count,
+                             fmt::ptr(user_account_entry_ptr));
         // should never happen
         return string{};
     }
 
     const auto &user_account_entry = *user_account_entry_ptr;
-    auto session_str = format("{} logged in {} time{}", user_account_entry.user, user_count, user_count > 1 ? "s" : "");
+    auto session_str =
+        format(FMT_STRING("{} logged in {} time{}"), user_account_entry.user, user_count, user_count > 1 ? "s" : "");
     if (!user_account_entry.hostname.empty()) {
-        session_str += format(" from {}", user_account_entry.hostname);
+        session_str += format(FMT_STRING(" from {}"), user_account_entry.hostname);
     }
     return session_str;
 }

--- a/lib/src/weather_info.cpp
+++ b/lib/src/weather_info.cpp
@@ -79,7 +79,8 @@ tuple<string, string, string, string> WeatherInfo::GetWeatherInfo() {
     //"http://wttr.in/?u&format=%l:+%t+%c+%C+%w+%m+%S+%s&lang=en"
     //"http://wttr.in/Lehi%20UT%20US?u&format=%l:+%t+%c+%C+%w+%m+%S+%s&lang=en"
     auto http_request = HttpRequest(HttpProtocol::HTTP, "wttr.in");
-    auto url = format("/{}?u&format=%l:+%t+%c+%C+%w+%m+%S+%s&lang=en", replace_all_copy(string{LOCATION}, " ", "%20"));
+    auto url = format(FMT_STRING("/{}?u&format=%l:+%t+%c+%C+%w+%m+%S+%s&lang=en"),
+                      replace_all_copy(string{LOCATION}, " ", "%20"));
     auto http_response = http_request.MakeRequest(url);
     if (!http_response) {
         return make_tuple(string{}, string{}, string{}, string{});
@@ -103,17 +104,17 @@ tuple<string, string, string, string> WeatherInfo::GetWeatherInfo() {
     }
 
     auto weather = trim_copy(weather_str.substr(0, match.position(0)));
-    PLOG_INFO << format("weather: '{}'", weather);
+    PLOG_INFO << format(FMT_STRING("weather: '{}'"), weather);
     auto sunrise_str = weather_str.substr(match.position(1), match.length(1));
-    PLOG_INFO << format("sunrise: '{}'", sunrise_str);
+    PLOG_INFO << format(FMT_STRING("sunrise: '{}'"), sunrise_str);
     auto sunset_str = weather_str.substr(match.position(2), match.length(2));
-    PLOG_INFO << format("sunset: '{}'", sunset_str);
+    PLOG_INFO << format(FMT_STRING("sunset: '{}'"), sunset_str);
 
     auto [sunrise_parsed, sunset_parsed] = ParseSunriseSunset(sunrise_str, sunset_str);
     sunrise_parsed = empty(sunrise_parsed) ? sunrise_str : sunrise_parsed;
     sunset_parsed = empty(sunset_parsed) ? sunset_str : sunset_parsed;
 
-    PLOG_INFO << format("weather: '{}, Sunrise (parsed): {}, Sunset (parsed): {}'",
+    PLOG_INFO << format(FMT_STRING("weather: '{}, Sunrise (parsed): {}, Sunset (parsed): {}'"),
                         weather,
                         sunrise_parsed,
                         sunset_parsed);


### PR DESCRIPTION
Refactor: adding `FMT_STRING("...") to all calls of `fmt::format` which
enables compile time checking of the format string and the arguments.
Luckily, since there were hundreds of calls to `fmt::format`, a single
`sed` search and replace made quick work of 90-95% of the calls.

Add: adding the `FMT_ENFORCE_COMPILE_STRING` define to each project
which forces an error if a developer adds a call to `fmt::format`
without also wrapping the format string within `FMT_STRING("...")`.

For example:

  previously the usage of format was:
  ```cpp
  PLOG_ERROR << fmt::format("ERROR: unable to find file {}", file_name);
  ```
  now this is changed to:
  ```cpp
  PLOG_ERROR << fmt::format(FMT_STRING("ERROR: unable to find file {}"), file_name);
  ```
  In addition, if any developer adds a `fmt::format` without using the
  FMT_STRING the compiler will fail in a spectacular fashion.

Closes issue #41 