### PR TITLE
Replace plog with a small fmt library wrapper

### DIFF
--- a/apps/mmotd_raw/src/main.cpp
+++ b/apps/mmotd_raw/src/main.cpp
@@ -69,7 +69,7 @@ int main_impl(int argc, char **argv) {
     setlocale(LC_ALL, "en_US.UTF-8");
 
     mmotd::algorithms::unused(argc, argv);
-    mmotd::logging::DefaultInitializeLogging("mmotd_raw.log");
+    mmotd::logging::InitializeLogging(argv[0]);
 
     PrintMmotdRaw();
     return EXIT_SUCCESS;
@@ -83,21 +83,15 @@ int main(int argc, char *argv[]) {
         retval = main_impl(argc, argv);
     } catch (boost::exception &ex) {
         auto diag = boost::diagnostic_information(ex);
-        auto error_str = format(FMT_STRING("caught boost::exception in main: {}"), diag);
-        PLOG_FATAL << error_str;
-        std::cerr << error_str << std::endl;
+        LOG_FATAL("caught boost::exception in main: {}", diag);
         retval = EXIT_FAILURE;
     } catch (const std::exception &ex) {
         auto diag = boost::diagnostic_information(ex);
-        auto error_str = format(FMT_STRING("caught std::exception in main: {}"), empty(diag) ? ex.what() : data(diag));
-        PLOG_FATAL << error_str;
-        std::cerr << error_str << std::endl;
+        LOG_FATAL("caught std::exception in main: {}", empty(diag) ? ex.what() : data(diag));
         retval = EXIT_FAILURE;
     } catch (...) {
         auto diag = boost::current_exception_diagnostic_information();
-        auto error_str = format(FMT_STRING("caught unknown exception in main: {}"), diag);
-        PLOG_FATAL << error_str;
-        std::cerr << error_str << std::endl;
+        LOG_FATAL("caught unknown exception in main: {}", diag);
         retval = EXIT_FAILURE;
     }
     return retval;

--- a/cmake/find_dependencies.cmake
+++ b/cmake/find_dependencies.cmake
@@ -117,19 +117,6 @@ if (NOT fmt_POPULATED)
     unset(MESSAGE_QUIET)
 endif ()
 
-# Component: PLOG.  A simple logging framework that does just enough of what needs doing.
-FetchContent_Declare(plog
-    GIT_REPOSITORY   https://github.com/SergiusTheBest/plog.git
-    GIT_TAG          1.1.5
-    GIT_PROGRESS     TRUE
-)
-FetchContent_GetProperties(plog)
-if (NOT plog_POPULATED)
-    FetchContent_Populate(plog)
-    add_library(plog INTERFACE)
-    target_include_directories(plog INTERFACE ${plog_SOURCE_DIR}/include)
-endif ()
-
 # Component: CLI11.  A simple command line/environment variable/config file parsing component which adds just enough
 #                    complexity needed for a project of this scale.
 FetchContent_Declare(cli11

--- a/cmake/target_common.cmake
+++ b/cmake/target_common.cmake
@@ -44,7 +44,7 @@ macro (setup_target_properties MMOTD_TARTET_NAME PROJECT_ROOT_INCLUDE_PATH)
         C_STANDARD 11
         C_STANDARD_REQUIRED on
         C_EXTENSIONS off
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED on
         CXX_EXTENSIONS off
         DISABLE_PRECOMPILE_HEADERS on
@@ -74,11 +74,6 @@ macro (setup_target_properties MMOTD_TARTET_NAME PROJECT_ROOT_INCLUDE_PATH)
         # This disables the BOOST_ASSERT macro and the "boost::assertion_failed",
         #  "boost::assertion_failed_msg" functions
         #PRIVATE BOOST_DISABLE_ASSERTS
-        # When defined plog will not define generic macro names like:
-        #  LOG, LOG_ERROR, LOGE, LOG_DEBUG, LOGI
-        #  These macro names often conflict with other preprocessor macros
-        #  and cause hard to track down errors.
-        PRIVATE PLOG_OMIT_LOG_DEFINES
         # When defined and compiler language is set to `-std=c++17` or higher,
         #  the lambda passed to scope_guard is required to be specified as `noexcept`.
         PRIVATE SG_REQUIRE_NOEXCEPT_IN_CPP17
@@ -139,6 +134,8 @@ macro (setup_target_properties MMOTD_TARTET_NAME PROJECT_ROOT_INCLUDE_PATH)
         # gnu only
         PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wtrampolines>
         PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wlogical-op>
+        # disable -- clang
+        PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Wno-gnu-zero-variadic-macro-arguments>
         # msvc only
         PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/EHsc> # /EHsc # Warning fix!
         PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/W4>   # /W4 increase warning level
@@ -186,7 +183,6 @@ macro (setup_target_properties MMOTD_TARTET_NAME PROJECT_ROOT_INCLUDE_PATH)
         PRIVATE ${BACKWARD_INCLUDE_DIRS}
         PRIVATE ${fort_SOURCE_DIR}/lib
         PRIVATE ${certify_SOURCE_DIR}/include
-        PRIVATE ${plog_SOURCE_DIR}/include
         PRIVATE ${fmt_SOURCE_DIR}/include
         PRIVATE ${random_SOURCE_DIR}/include
         PRIVATE ${json_SOURCE_DIR}/include

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -37,6 +37,8 @@ add_library (
     src/logging.cpp
     src/mac_address.cpp
     src/network_device.cpp
+    src/source_location.cpp
+    src/source_location_common.cpp
     src/version.cpp
     )
 

--- a/common/assertion/src/exception.cpp
+++ b/common/assertion/src/exception.cpp
@@ -2,10 +2,9 @@
 #include "common/assertion/include/assertion.h"
 #include "common/assertion/include/exception.h"
 #include "common/include/algorithm.h"
+#include "common/include/logging.h"
 
 #include <stdexcept>
-
-#include <plog/Log.h>
 
 using namespace std;
 
@@ -14,13 +13,13 @@ namespace mmotd::assertion {
 InvalidArgument::InvalidArgument(const char *message, bool includes_stack_trace) :
     boost::exception(),
     std::invalid_argument(includes_stack_trace ? message : MakeExceptionMessage("InvalidArgument", message)) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 InvalidArgument::InvalidArgument(const std::string &message, bool includes_stack_trace) :
     boost::exception(),
     std::invalid_argument(includes_stack_trace ? message : MakeExceptionMessage("InvalidArgument", message.c_str())) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 InvalidArgument::~InvalidArgument() noexcept {
@@ -29,13 +28,13 @@ InvalidArgument::~InvalidArgument() noexcept {
 DomainError::DomainError(const char *message, bool includes_stack_trace) :
     boost::exception(),
     std::domain_error(includes_stack_trace ? message : MakeExceptionMessage("DomainError", message)) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 DomainError::DomainError(const std::string &message, bool includes_stack_trace) :
     boost::exception(),
     std::domain_error(includes_stack_trace ? message : MakeExceptionMessage("DomainError", message.c_str())) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 DomainError::~DomainError() noexcept {
@@ -44,13 +43,13 @@ DomainError::~DomainError() noexcept {
 LengthError::LengthError(const char *message, bool includes_stack_trace) :
     boost::exception(),
     std::length_error(includes_stack_trace ? message : MakeExceptionMessage("LengthError", message)) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 LengthError::LengthError(const std::string &message, bool includes_stack_trace) :
     boost::exception(),
     std::length_error(includes_stack_trace ? message : MakeExceptionMessage("LengthError", message.c_str())) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 LengthError::~LengthError() noexcept {
@@ -59,13 +58,13 @@ LengthError::~LengthError() noexcept {
 OutOfRange::OutOfRange(const char *message, bool includes_stack_trace) :
     boost::exception(),
     std::out_of_range(includes_stack_trace ? message : MakeExceptionMessage("OutOfRangeError", message)) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 OutOfRange::OutOfRange(const std::string &message, bool includes_stack_trace) :
     boost::exception(),
     std::out_of_range(includes_stack_trace ? message : MakeExceptionMessage("OutOfRangeError", message.c_str())) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 OutOfRange::~OutOfRange() noexcept {
@@ -74,13 +73,13 @@ OutOfRange::~OutOfRange() noexcept {
 RuntimeError::RuntimeError(const char *message, bool includes_stack_trace) :
     boost::exception(),
     std::runtime_error(includes_stack_trace ? message : MakeExceptionMessage("RuntimeError", message)) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 RuntimeError::RuntimeError(const std::string &message, bool includes_stack_trace) :
     boost::exception(),
     std::runtime_error(includes_stack_trace ? message : MakeExceptionMessage("RuntimeError", message.c_str())) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 RuntimeError::~RuntimeError() noexcept {
@@ -88,13 +87,13 @@ RuntimeError::~RuntimeError() noexcept {
 
 RangeError::RangeError(const char *message, bool includes_stack_trace) :
     boost::exception(), std::range_error(includes_stack_trace ? message : MakeExceptionMessage("RangeError", message)) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 RangeError::RangeError(const std::string &message, bool includes_stack_trace) :
     boost::exception(),
     std::range_error(includes_stack_trace ? message : MakeExceptionMessage("RangeError", message.c_str())) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 RangeError::~RangeError() noexcept {
@@ -103,13 +102,13 @@ RangeError::~RangeError() noexcept {
 OverflowError::OverflowError(const char *message, bool includes_stack_trace) :
     boost::exception(),
     std::overflow_error(includes_stack_trace ? message : MakeExceptionMessage("OverflowError", message)) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 OverflowError::OverflowError(const std::string &message, bool includes_stack_trace) :
     boost::exception(),
     std::overflow_error(includes_stack_trace ? message : MakeExceptionMessage("OverflowError", message.c_str())) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 OverflowError::~OverflowError() noexcept {
@@ -118,13 +117,13 @@ OverflowError::~OverflowError() noexcept {
 UnderflowError::UnderflowError(const char *message, bool includes_stack_trace) :
     boost::exception(),
     std::underflow_error(includes_stack_trace ? message : MakeExceptionMessage("UnderflowError", message)) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 UnderflowError::UnderflowError(const std::string &message, bool includes_stack_trace) :
     boost::exception(),
     std::underflow_error(includes_stack_trace ? message : MakeExceptionMessage("UnderflowError", message.c_str())) {
-    PLOG_ERROR << what();
+    LOG_ERROR("{}", what());
 }
 
 UnderflowError::~UnderflowError() noexcept {

--- a/common/include/algorithm.h
+++ b/common/include/algorithm.h
@@ -219,4 +219,10 @@ constexpr bool value_in_range(U value, T min, T max_plus_one) noexcept {
     return cmp_greater_equal(value, min) && cmp_less(value, max_plus_one);
 }
 
+template<typename T, class U>
+constexpr bool value_outside_range(U value, T min, T max_plus_one) noexcept {
+    using namespace std;
+    return cmp_less(value, min) || cmp_greater_equal(value, max_plus_one);
+}
+
 } // namespace mmotd::algorithms

--- a/common/include/app_options.h
+++ b/common/include/app_options.h
@@ -1,6 +1,7 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
 #include "common/include/algorithm.h"
+#include "common/include/logging.h"
 
 #include <cstdint>
 #include <iosfwd>
@@ -19,11 +20,11 @@ public:
     std::string to_string() const;
 
     enum class ColorWhen { Always, Auto, Never, NotSet };
-    enum class Verbosity : std::int64_t { Off = 0, Info, Debug, Verbose, Inavlid };
+    enum class LogSeverity { None = 0, Fatal = 1, Error = 2, Warning = 3, Info = 4, Debug = 5, Verbose = 6, NotSet };
 
-    bool IsVerboseSet() const noexcept;
-    bool IsVerbosityEnabled() const noexcept;
-    Verbosity GetVerbosityLevel() const noexcept;
+    bool IsLogSeveritySet() const noexcept;
+    LogSeverity GetLogSeverity() const noexcept;
+    mmotd::logging::Severity GetLoggingSeverity() const noexcept;
     bool IsColorWhenSet() const;
     bool IsColorDisabled() const;
     ColorWhen GetColorWhen() const;
@@ -62,7 +63,7 @@ public:
     bool IsQuoteSet() const { return !indeterminate(quote); }
     bool GetQuoteValue() const { return quote.value; }
 
-    void SetVerbose(std::int64_t count) noexcept;
+    bool SetLogSeverity(const std::vector<std::string> &severities);
     bool SetColorWhen(const std::vector<std::string> &whens);
     bool SetTemplatePath(const std::vector<std::string> &paths);
     void SetLastLogin(int value) { last_login = value == -1 ? false : true; }
@@ -88,7 +89,7 @@ public:
     std::optional<std::string> GetOutputTemplatePath() const;
 
 private:
-    Verbosity verbose = Verbosity::Inavlid;
+    LogSeverity log_severity = LogSeverity::NotSet;
     ColorWhen color_when = ColorWhen::NotSet;
     std::string config_path;
     std::string template_path;

--- a/common/include/chrono_io.h
+++ b/common/include/chrono_io.h
@@ -1,6 +1,7 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
 #include "common/assertion/include/assertion.h"
+#include "common/include/logging.h"
 
 #include <chrono>
 #include <cstdlib>
@@ -13,13 +14,12 @@
 #include <date/date.h>
 #include <date/tz.h>
 #include <fmt/ostream.h>
-#include <plog/Log.h>
 
 namespace mmotd::chrono::io {
 
 namespace detail {
 
-inline std::string to_string(date::time_of_day<std::chrono::seconds> tod, std::string chrono_format) {
+inline std::string to_string(date::time_of_day<std::chrono::seconds> tod, const char *chrono_format) {
     auto fields = date::fields{tod};
     auto result = date::format(chrono_format, fields);
     if (auto am_index = result.rfind("AM"); am_index != std::string::npos) {
@@ -34,9 +34,8 @@ inline std::string to_string(date::time_of_day<std::chrono::seconds> tod, std::s
 }
 
 template<class Clock, class Duration>
-inline std::string to_string(std::chrono::time_point<Clock, Duration> time_point, std::string chrono_format) {
+inline std::string to_string(std::chrono::time_point<Clock, Duration> time_point, const char *chrono_format) {
     auto time_point_zoned = date::make_zoned(date::locate_zone("America/Denver"), time_point);
-    // auto time_point_zoned = date::make_zoned(date::locate_zone("Americas/Denver"), time_point);
     auto result = date::format(chrono_format, time_point_zoned);
     if (auto am_index = result.rfind("AM"); am_index != std::string::npos) {
         result[am_index] = 'a';
@@ -49,18 +48,15 @@ inline std::string to_string(std::chrono::time_point<Clock, Duration> time_point
     return result;
 }
 
-inline auto from_string(std::string input, std::string chrono_format) {
+inline auto from_string(std::string input, const char *chrono_format) {
     using namespace std::chrono;
     auto seconds_since_midnight = std::chrono::seconds{};
     std::istringstream stream{input};
     stream >> date::parse(chrono_format, seconds_since_midnight);
     auto tod = date::make_time(seconds_since_midnight);
-    PLOG_VERBOSE << fmt::format(FMT_STRING("parsed time: {}, using format: {}, from string: '{}'"),
-                                tod,
-                                chrono_format,
-                                input);
+    LOG_VERBOSE("parsed time: {}, using format: {}, from string: '{}'", tod, chrono_format, input);
     if (stream.fail()) {
-        PLOG_ERROR << fmt::format(FMT_STRING("failed to parse string: '{}', using format: {}"), input, chrono_format);
+        LOG_ERROR("failed to parse string: '{}', using format: {}", input, chrono_format);
     }
     return !stream.fail() ? std::make_optional(tod) : std::nullopt;
 }
@@ -70,27 +66,22 @@ inline std::optional<std::size_t> get_current_hour() {
     auto hour_str = date::format("%H", now_time_point);
     const auto &loc = std::locale();
     if (size(hour_str) != std::size_t{2}) {
-        PLOG_ERROR << fmt::format(FMT_STRING("hour is not two characters wide: '{}', current time: '{}'"),
-                                  hour_str,
-                                  now_time_point);
+        LOG_ERROR("hour is not two characters wide: '{}', current time: '{}'", hour_str, now_time_point);
         return std::nullopt;
     } else if (!std::isdigit(hour_str.front(), loc) || !std::isdigit(hour_str.back(), loc)) {
-        PLOG_ERROR << fmt::format(FMT_STRING("hour is not digit characters: '{}', current time: '{}'"),
-                                  hour_str,
-                                  now_time_point);
+        LOG_ERROR("hour is not digit characters: '{}', current time: '{}'", hour_str, now_time_point);
         return std::nullopt;
     } else {
         if (hour_str.front() == '0') {
             hour_str = hour_str.substr(1);
         }
         auto hour = stoull(hour_str, nullptr, 10);
-        PLOG_VERBOSE << fmt::format(FMT_STRING("current hour: '{}', current time: '{}'"), hour, now_time_point);
+        LOG_VERBOSE("current hour: '{}', current time: '{}'", hour, now_time_point);
         if (hour > 23) {
-            PLOG_VERBOSE << fmt::format(
-                FMT_STRING("current hour is outside normal range {{0-24]: '{}', new hour: {}, current time: '{}'"),
-                hour,
-                std::size_t{23},
-                now_time_point);
+            LOG_VERBOSE("current hour is outside normal range {{0-24]: '{}', new hour: {}, current time: '{}'",
+                        hour,
+                        std::size_t{23},
+                        now_time_point);
             hour = std::size_t{23};
         }
         return {hour};

--- a/common/include/logging.h
+++ b/common/include/logging.h
@@ -1,52 +1,105 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
-#include "common/include/app_options.h"
+#include "common/include/source_location.h"
 
 #include <string>
 
-#include <plog/Log.h>
+#include <boost/current_function.hpp>
+#include <fmt/color.h>
+#include <fmt/format.h>
 
 namespace mmotd::logging {
 
-inline static const constexpr int CONSOLE_LOG = 1;
+enum class Severity { none = 0, fatal = 1, error = 2, warning = 3, info = 4, debug = 5, verbose = 6 };
 
-void DefaultInitializeLogging(const std::string &filename);
-void UpdateSeverityFilter(Options::Verbosity verbosity);
+namespace logging_detail {
+
+extern mmotd::logging::Severity LOGGING_SEVERITY;
+
+}
+
+inline Severity GetSeverity() noexcept {
+    return mmotd::logging::logging_detail::LOGGING_SEVERITY;
+}
+
+inline void UpdateSeverity(Severity severity) {
+    mmotd::logging::logging_detail::LOGGING_SEVERITY = severity;
+}
+
+void InitializeLogging(const std::string &binary_name);
+
+void LogInternal(const mmotd::source_location::SourceLocation &source_location,
+                 Severity severity,
+                 fmt::string_view format,
+                 fmt::format_args args);
+
+template<typename S, typename... Args>
+void Log(const char *file, long line, const char *function, Severity severity, const S &format, Args &&...args) {
+    LogInternal(mmotd::source_location::SourceLocation(file, line, function),
+                severity,
+                format,
+                fmt::make_args_checked<Args...>(format, args...));
+}
 
 } // namespace mmotd::logging
 
-#define MMOTD_LOG_VERBOSE(msg_)                                    \
-    do {                                                           \
-        PLOG(plog::verbose) << msg_;                               \
-        PLOG_(mmotd::logging::CONSOLE_LOG, plog::verbose) << msg_; \
+#define LOG_FATAL(format, ...)                                                  \
+    do {                                                                        \
+        if (mmotd::logging::GetSeverity() >= mmotd::logging::Severity::fatal) { \
+            mmotd::logging::Log(__FILE__,                                       \
+                                __LINE__,                                       \
+                                BOOST_CURRENT_FUNCTION,                         \
+                                mmotd::logging::Severity::fatal,                \
+                                FMT_STRING(format) __VA_OPT__(, ) __VA_ARGS__); \
+        }                                                                       \
     } while (false)
-#define MMOTD_LOG_DEBUG(msg_)                                    \
-    do {                                                         \
-        PLOG(plog::debug) << msg_;                               \
-        PLOG_(mmotd::logging::CONSOLE_LOG, plog::debug) << msg_; \
+#define LOG_ERROR(format, ...)                                                  \
+    do {                                                                        \
+        if (mmotd::logging::GetSeverity() >= mmotd::logging::Severity::error) { \
+            mmotd::logging::Log(__FILE__,                                       \
+                                __LINE__,                                       \
+                                BOOST_CURRENT_FUNCTION,                         \
+                                mmotd::logging::Severity::error,                \
+                                FMT_STRING(format) __VA_OPT__(, ) __VA_ARGS__); \
+        }                                                                       \
     } while (false)
-#define MMOTD_LOG_INFO(msg_)                                    \
-    do {                                                        \
-        PLOG(plog::info) << msg_;                               \
-        PLOG_(mmotd::logging::CONSOLE_LOG, plog::info) << msg_; \
+#define LOG_WARNING(format, ...)                                                  \
+    do {                                                                          \
+        if (mmotd::logging::GetSeverity() >= mmotd::logging::Severity::warning) { \
+            mmotd::logging::Log(__FILE__,                                         \
+                                __LINE__,                                         \
+                                BOOST_CURRENT_FUNCTION,                           \
+                                mmotd::logging::Severity::warning,                \
+                                FMT_STRING(format) __VA_OPT__(, ) __VA_ARGS__);   \
+        }                                                                         \
     } while (false)
-#define MMOTD_LOG_WARNING(msg_)                                    \
-    do {                                                           \
-        PLOG(plog::warning) << msg_;                               \
-        PLOG_(mmotd::logging::CONSOLE_LOG, plog::warning) << msg_; \
+#define LOG_INFO(format, ...)                                                   \
+    do {                                                                        \
+        if (mmotd::logging::GetSeverity() >= mmotd::logging::Severity::info) {  \
+            mmotd::logging::Log(__FILE__,                                       \
+                                __LINE__,                                       \
+                                BOOST_CURRENT_FUNCTION,                         \
+                                mmotd::logging::Severity::info,                 \
+                                FMT_STRING(format) __VA_OPT__(, ) __VA_ARGS__); \
+        }                                                                       \
     } while (false)
-#define MMOTD_LOG_ERROR(msg_)                                    \
-    do {                                                         \
-        PLOG(plog::error) << msg_;                               \
-        PLOG_(mmotd::logging::CONSOLE_LOG, plog::error) << msg_; \
+#define LOG_DEBUG(format, ...)                                                  \
+    do {                                                                        \
+        if (mmotd::logging::GetSeverity() >= mmotd::logging::Severity::debug) { \
+            mmotd::logging::Log(__FILE__,                                       \
+                                __LINE__,                                       \
+                                BOOST_CURRENT_FUNCTION,                         \
+                                mmotd::logging::Severity::debug,                \
+                                FMT_STRING(format) __VA_OPT__(, ) __VA_ARGS__); \
+        }                                                                       \
     } while (false)
-#define MMOTD_LOG_FATAL(msg_)                                    \
-    do {                                                         \
-        PLOG(plog::fatal) << msg_;                               \
-        PLOG_(mmotd::logging::CONSOLE_LOG, plog::fatal) << msg_; \
-    } while (false)
-#define MMOTD_LOG_NONE(msg_)                                    \
-    do {                                                        \
-        PLOG(plog::none) << msg_;                               \
-        PLOG_(mmotd::logging::CONSOLE_LOG, plog::none) << msg_; \
+#define LOG_VERBOSE(format, ...)                                                  \
+    do {                                                                          \
+        if (mmotd::logging::GetSeverity() >= mmotd::logging::Severity::verbose) { \
+            mmotd::logging::Log(__FILE__,                                         \
+                                __LINE__,                                         \
+                                BOOST_CURRENT_FUNCTION,                           \
+                                mmotd::logging::Severity::verbose,                \
+                                FMT_STRING(format) __VA_OPT__(, ) __VA_ARGS__);   \
+        }                                                                         \
     } while (false)

--- a/common/include/source_location.h
+++ b/common/include/source_location.h
@@ -1,0 +1,26 @@
+// vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#pragma once
+#include "common/include/big_five_macros.h"
+
+#include <cstdint>
+#include <string>
+
+namespace mmotd::source_location {
+
+class SourceLocation {
+    friend std::string to_string(const SourceLocation &source_location);
+
+public:
+    SourceLocation(const char *file, long line, const char *function);
+    DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_DESTRUCTOR(SourceLocation);
+
+private:
+    std::string to_string() const;
+
+    std::uint32_t line_ = 0;
+    // std::uint32_t column_ = 0;
+    std::string file_name_;
+    std::string function_name_;
+};
+
+} // namespace mmotd::source_location

--- a/common/include/source_location_common.h
+++ b/common/include/source_location_common.h
@@ -1,0 +1,20 @@
+// vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#pragma once
+#include <string>
+
+namespace mmotd::source_location {
+
+enum class FunctionArgStrategy { remove, replace, none };
+enum class FunctionReturnStrategy { remove, none };
+
+std::string TrimFileName(const char *file) noexcept;
+std::string TrimFunction(const char *function,
+                         FunctionArgStrategy arg_strategy = FunctionArgStrategy::remove,
+                         FunctionReturnStrategy return_strategy = FunctionReturnStrategy::none) noexcept;
+
+std::string StripFunctionArgs(std::string function) noexcept;
+std::string StripFunctionReturn(std::string function) noexcept;
+std::string StripAnonymousNamespace(std::string function) noexcept;
+std::string StripNamespaces(std::string function) noexcept;
+
+} // namespace mmotd::source_location

--- a/common/results/src/output_column.cpp
+++ b/common/results/src/output_column.cpp
@@ -10,9 +10,10 @@
 
 // #include "common/results/include/template_string.h"
 
+#include "common/include/logging.h"
+
 #include <boost/uuid/uuid_io.hpp>
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using mmotd::information::Informations;
@@ -49,10 +50,7 @@ void Column::AddNamesValues(const Informations &informations, PositionIndex posi
         row.SetNameValue(informations);
     }
     for (const auto &row : rows_) {
-        PLOG_VERBOSE << format(FMT_STRING("row[{}] = [{}] {}"),
-                               row.GetRowNumber(),
-                               fmt::ptr(&row),
-                               row.item_to_string());
+        LOG_VERBOSE("row[{}] = [{}] {}", row.GetRowNumber(), fmt::ptr(&row), row.item_to_string());
     }
 }
 

--- a/common/results/src/output_frame.cpp
+++ b/common/results/src/output_frame.cpp
@@ -5,6 +5,7 @@
 #include "common/include/information.h"
 #include "common/include/information_decls.h"
 #include "common/include/informations.h"
+#include "common/include/logging.h"
 #include "common/results/include/output_column.h"
 #include "common/results/include/output_frame.h"
 #include "common/results/include/output_row.h"
@@ -20,7 +21,6 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <fmt/color.h>
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using mmotd::information::InformationId;
@@ -176,7 +176,7 @@ void Frame::RemoveEmptyRows() {
     auto row_numbers = GetFirstLastRowNumbers();
     for (auto i = begin(row_numbers); i != end(row_numbers); ++i) {
         auto row_number = *i;
-        PLOG_VERBOSE << format(FMT_STRING("inspecting row: {}, empty rows: {}"), row_number, empty_row_count);
+        LOG_VERBOSE("inspecting row: {}, empty rows: {}", row_number, empty_row_count);
         auto row_ids = GetRowIds(row_number);
         if (empty(row_ids)) {
             ++empty_row_count;
@@ -297,7 +297,7 @@ size_t Frame::GetColumnCount(bool include_name_value) const {
             }
         }
     }
-    PLOG_VERBOSE << format(FMT_STRING("column count: {}, include name value: {}"), total_count, include_name_value);
+    LOG_VERBOSE("column count: {}, include name value: {}", total_count, include_name_value);
     return total_count;
 }
 

--- a/common/results/src/output_row.cpp
+++ b/common/results/src/output_row.cpp
@@ -2,6 +2,7 @@
 #include "common/assertion/include/assertion.h"
 #include "common/include/information.h"
 #include "common/include/informations.h"
+#include "common/include/logging.h"
 #include "common/results/include/output_common.h"
 #include "common/results/include/output_position_index.h"
 #include "common/results/include/output_row.h"
@@ -13,7 +14,6 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using mmotd::information::Informations;
@@ -83,11 +83,11 @@ bool Row::BalanceNameValueSize() {
 
 size_t Row::UpdateRowNumber(int row_number) {
     MMOTD_PRECONDITIONS(size(names_) == size(values_), "output names and values must be equal sizes");
-    PLOG_VERBOSE << format(FMT_STRING("updating row number: {} to: {} for name: '{}', value: '{}'"),
-                           item_.row_index,
-                           row_number,
-                           GetName(0),
-                           GetValue(0));
+    LOG_VERBOSE("updating row number: {} to: {} for name: '{}', value: '{}'",
+                item_.row_index,
+                row_number,
+                GetName(0),
+                GetValue(0));
     item_.row_index = row_number;
     return size(names_);
 }
@@ -98,19 +98,17 @@ void Row::SetNameValue(const Informations &informations) {
         auto sub_color = item_.GetNameColor(i);
         auto sub_row_name = format(FMT_STRING("{}{}"), GetRowNumber(), string(size_t{1}, 'a' + i));
         if (empty(sub_name)) {
-            PLOG_VERBOSE << format(FMT_STRING("skipping row {} since it's name is empty"), sub_row_name);
+            LOG_VERBOSE("skipping row {} since it's name is empty", sub_row_name);
             continue;
         }
         auto information_index = static_cast<size_t>(item_.repeatable_index);
         auto name_xfr_ids = TemplateString::ReplaceInformationIds(sub_name, informations, information_index);
         if (empty(name_xfr_ids)) {
-            PLOG_VERBOSE << format(
-                FMT_STRING("skipping row {} since the 'name' converted from information ids is empty"),
-                sub_row_name);
+            LOG_VERBOSE("skipping row {} since the 'name' converted from information ids is empty", sub_row_name);
             continue;
         }
         auto modified_name = TemplateString::ReplaceEmbeddedColorCodes(name_xfr_ids, sub_color);
-        PLOG_VERBOSE << format(FMT_STRING("adding to row {}, name: '{}'"), sub_row_name, modified_name);
+        LOG_VERBOSE("adding to row {}, name: '{}'", sub_row_name, modified_name);
         AddName(modified_name);
     }
     for (auto i = size_t{0}; i != size(item_.value); ++i) {
@@ -118,19 +116,17 @@ void Row::SetNameValue(const Informations &informations) {
         auto sub_color = item_.GetValueColor(i);
         auto sub_row_name = format(FMT_STRING("{}{}"), GetRowNumber(), string(size_t{1}, 'a' + i));
         if (empty(sub_value)) {
-            PLOG_VERBOSE << format(FMT_STRING("skipping row {} since it's value is empty"), sub_row_name);
+            LOG_VERBOSE("skipping row {} since it's value is empty", sub_row_name);
             continue;
         }
         auto information_index = static_cast<size_t>(item_.repeatable_index);
         auto value_xfr_ids = TemplateString::ReplaceInformationIds(sub_value, informations, information_index);
         if (empty(value_xfr_ids)) {
-            PLOG_VERBOSE << format(
-                FMT_STRING("skipping row {} since the 'value' converted from information ids is empty"),
-                sub_row_name);
+            LOG_VERBOSE("skipping row {} since the 'value' converted from information ids is empty", sub_row_name);
             continue;
         }
         auto modified_value = TemplateString::ReplaceEmbeddedColorCodes(value_xfr_ids, sub_color);
-        PLOG_VERBOSE << format(FMT_STRING("adding to row {}, value: '{}'"), sub_row_name, modified_value);
+        LOG_VERBOSE("adding to row {}, value: '{}'", sub_row_name, modified_value);
         AddValue(modified_value);
     }
 }

--- a/common/results/src/output_row_number_sentinals.cpp
+++ b/common/results/src/output_row_number_sentinals.cpp
@@ -1,4 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/logging.h"
 #include "common/results/include/output_row_number_sentinals.h"
 
 #include <limits>
@@ -6,7 +7,6 @@
 #include <string>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using namespace std;
@@ -16,7 +16,7 @@ static constexpr const int INVALID_ROW = std::numeric_limits<int>::max();
 namespace mmotd::results {
 
 RowNumberSentinals::RowNumberSentinals(value_type begin, value_type end) : begin_value_(begin), end_value_(end) {
-    PLOG_VERBOSE << format(FMT_STRING("row sentinal created: {}"), to_string());
+    LOG_VERBOSE("row sentinal created: {}", to_string());
 }
 
 RowNumberSentinals::iterator RowNumberSentinals::begin() {

--- a/common/results/src/output_template.cpp
+++ b/common/results/src/output_template.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/algorithm.h"
+#include "common/include/logging.h"
 #include "common/results/include/output_template.h"
 
 #include <filesystem>
@@ -11,7 +12,6 @@
 #include <boost/exception/diagnostic_information.hpp>
 #include <fmt/color.h>
 #include <nlohmann/json.hpp>
-#include <plog/Log.h>
 
 using nlohmann::json;
 namespace fs = std::filesystem;
@@ -47,7 +47,7 @@ string OutputTemplate::GetDefaultTemplate() const {
 bool OutputTemplate::ParseTemplateFile(string template_file_name) {
     auto ec = std::error_code{};
     if (auto file_exists = fs::exists(template_file_name, ec); !file_exists || ec) {
-        PLOG_ERROR << format(FMT_STRING("determining whether template file {} exists"), template_file_name);
+        LOG_ERROR("determining whether template file {} exists", template_file_name);
         return false;
     }
     return ParseJson(template_file_name);

--- a/common/results/src/template_substring.cpp
+++ b/common/results/src/template_substring.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/app_options.h"
+#include "common/include/logging.h"
 #include "common/results/include/template_substring.h"
 
 #include <iterator>
@@ -10,7 +11,6 @@
 #include <boost/range/iterator.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <fmt/color.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using namespace std;
@@ -41,19 +41,15 @@ void TemplateSubstring::SetValueSubstringRange(const SubstringRange &new_range,
     if (!new_range.match(text)) {
         return;
     } else if (existing_range.empty()) {
-        PLOG_VERBOSE << format(FMT_STRING("{} was empty, now=[{},{}], text=\"{}\""),
-                               name,
-                               new_range.position(),
-                               new_range.size(),
-                               text);
+        LOG_VERBOSE("{} was empty, now=[{},{}], text=\"{}\"", name, new_range.position(), new_range.size(), text);
     } else {
-        PLOG_VERBOSE << format(FMT_STRING("{} was=[{},{}], now=[{},{}], text=\"{}\""),
-                               name,
-                               existing_range.position(),
-                               existing_range.size(),
-                               new_range.position(),
-                               new_range.size(),
-                               text);
+        LOG_VERBOSE("{} was=[{},{}], now=[{},{}], text=\"{}\"",
+                    name,
+                    existing_range.position(),
+                    existing_range.size(),
+                    new_range.position(),
+                    new_range.size(),
+                    text);
     }
     existing_range = new_range;
 }
@@ -87,24 +83,24 @@ ColorDefinitions TemplateSubstring::GetColorDefinitions() const {
 
 void TemplateSubstring::SetPrefix(SubstringRange prefix) {
     SetValueSubstringRange(prefix, prefix_, "prefix", GetRawText());
-    PLOG_VERBOSE << format(FMT_STRING("updated prefix, template substring=\"{}\""), to_string(nullptr));
+    LOG_VERBOSE("updated prefix, template substring=\"{}\"", to_string(nullptr));
 }
 
 void TemplateSubstring::SetSuffix(SubstringRange suffix) {
     SetValueSubstringRange(suffix, suffix_, "suffix", GetRawText());
-    PLOG_VERBOSE << format(FMT_STRING("updated suffix, template substring=\"{}\""), to_string());
+    LOG_VERBOSE("updated suffix, template substring=\"{}\"", to_string());
 }
 
 void TemplateSubstring::SetSubstringText(SubstringRange substring_text) {
     SetValueSubstringRange(substring_text, substring_text_, "substring_text", GetRawText());
-    PLOG_VERBOSE << format(FMT_STRING("updated substring text, template substring=\"{}\""), to_string());
+    LOG_VERBOSE("updated substring text, template substring=\"{}\"", to_string());
 }
 
 void TemplateSubstring::SetColorDefinitions(ColorDefinitions color_definitions) {
     color_definitions_ = color_definitions;
-    PLOG_VERBOSE << format(FMT_STRING("set color definition={} in text=\"{}\""),
-                           color_definitions_to_string(color_definitions_),
-                           GetRawText());
+    LOG_VERBOSE("set color definition={} in text=\"{}\"",
+                color_definitions_to_string(color_definitions_),
+                GetRawText());
 }
 
 string TemplateSubstring::to_string() const {
@@ -124,11 +120,11 @@ string TemplateSubstring::to_string() const {
 }
 
 string TemplateSubstring::to_string(function<fmt::text_style(string)> convert_color) const {
-    PLOG_VERBOSE << format(FMT_STRING("prefix=\"{}\", color=\"{}\", text=\"{}\", suffix=\"{}\""),
-                           GetPrefix(),
-                           color_definitions_to_string(GetColorDefinitions()),
-                           GetSubstring(),
-                           GetSuffix());
+    LOG_VERBOSE("prefix=\"{}\", color=\"{}\", text=\"{}\", suffix=\"{}\"",
+                GetPrefix(),
+                color_definitions_to_string(GetColorDefinitions()),
+                GetSubstring(),
+                GetSuffix());
     auto substring_text = GetSubstring();
     if (auto colors_disabled = AppOptions::Instance().GetOptions().IsColorDisabled(); !colors_disabled) {
         const auto &colors = GetColorDefinitions();

--- a/common/results/src/template_substrings.cpp
+++ b/common/results/src/template_substrings.cpp
@@ -1,4 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/logging.h"
 #include "common/results/include/template_substring.h"
 #include "common/results/include/template_substrings.h"
 
@@ -9,7 +10,6 @@
 #include <boost/iterator/indirect_iterator.hpp>
 #include <boost/range/range_fwd.hpp>
 #include <fmt/color.h>
-#include <plog/Log.h>
 
 using namespace std;
 using fmt::format;
@@ -101,7 +101,7 @@ string TemplateSubstrings::to_string(function<fmt::text_style(string)> convert_c
     auto i = size_t{0};
     for (const auto &template_substring : *this) {
         auto substring_output = template_substring.to_string(convert_color);
-        PLOG_VERBOSE << format(FMT_STRING("{}: formatted text=\"{}\""), i, substring_output);
+        LOG_VERBOSE("{}: formatted text=\"{}\"", i, substring_output);
         output += substring_output;
     }
     return output;

--- a/common/src/information.cpp
+++ b/common/src/information.cpp
@@ -1,12 +1,12 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/algorithm.h"
 #include "common/include/information.h"
+#include "common/include/logging.h"
 
 #include <string>
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using namespace std;

--- a/common/src/information_decls.cpp
+++ b/common/src/information_decls.cpp
@@ -1,6 +1,7 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/information_decls.h"
 #include "common/include/information_definitions.h"
+#include "common/include/logging.h"
 
 #include <array>
 #include <string>
@@ -9,7 +10,6 @@
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using namespace std;

--- a/common/src/information_definitions.cpp
+++ b/common/src/information_definitions.cpp
@@ -2,6 +2,7 @@
 #include "common/assertion/include/assertion.h"
 #include "common/assertion/include/exception.h"
 #include "common/include/information_definitions.h"
+#include "common/include/logging.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -10,7 +11,6 @@
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using namespace std;

--- a/common/src/logging.cpp
+++ b/common/src/logging.cpp
@@ -1,73 +1,248 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/assertion/include/assertion.h"
+#include "common/include/chrono_io.h"
 #include "common/include/logging.h"
+#include "common/include/source_location.h"
+#include "common/include/version.h"
 
-#include <cassert>
-#include <cstddef>
+#include <charconv>
+#include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
-#include <iostream>
+#include <ios>
+#include <iterator>
+#include <mutex>
 #include <string>
-#include <utility>
+#include <thread>
 
+#include <date/date.h>
+#include <date/tz.h>
+#include <fmt/color.h>
 #include <fmt/format.h>
-#include <plog/Appenders/ColorConsoleAppender.h>
-#include <plog/Appenders/RollingFileAppender.h>
-#include <plog/Formatters/TxtFormatter.h>
-#include <plog/Init.h>
-#include <plog/Log.h>
-#include <plog/Severity.h>
+#include <fmt/ostream.h>
 
-using fmt::format;
+namespace fs = std::filesystem;
 using namespace std;
+
+namespace mmotd::logging::logging_detail {
+
+mmotd::logging::Severity LOGGING_SEVERITY = mmotd::logging::Severity::verbose;
+
+}
+
+namespace {
+
+static std::mutex LOGGER_IO_MUTEX;
+
+class FileLogger {
+public:
+    FileLogger() = default;
+    ~FileLogger() { Close(); }
+
+    void Open(const fs::path &file_path);
+    void Close();
+
+    void WriteLog(mmotd::logging::Severity severity, const fmt::memory_buffer &input, bool only_file_output = false);
+
+private:
+    std::FILE *file_ = nullptr;
+    std::mutex mutex_;
+};
+
+void FileLogger::Open(const fs::path &file_path) {
+    Close();
+    auto lock = lock_guard<mutex>(mutex_);
+    file_ = std::fopen(file_path.c_str(), "w");
+    if (file_ == nullptr) {
+        auto data = fmt::memory_buffer{};
+        format_system_error(data, errno, fmt::format(FMT_STRING("cannot open file '{}'"), file_path.string()));
+        auto style = fmt::text_style(fmt::emphasis::bold) | fmt::fg(fmt::terminal_color::red);
+        fmt::print(stderr, style, FMT_STRING("{}"), string_view(data.data(), data.size()));
+    }
+}
+
+void FileLogger::Close() {
+    auto lock = lock_guard<mutex>(mutex_);
+    if (file_ != nullptr) {
+        std::fclose(file_);
+        file_ = nullptr;
+    }
+}
+
+void FileLogger::WriteLog(mmotd::logging::Severity severity, const fmt::memory_buffer &input, bool only_file_output) {
+    using namespace mmotd::logging;
+    auto lock = lock_guard<mutex>(mutex_);
+    if (file_ != nullptr) {
+        fmt::print(file_, FMT_STRING("{}"), string_view(data(input), size(input)));
+    }
+    if (!only_file_output && severity <= Severity::fatal) {
+        fmt::print(stderr, FMT_STRING("{}"), string_view(data(input), size(input)));
+    }
+}
+
+// This is a short lived app -- intentionally create a leaked object so it is created on first demand
+//  and lives beyond the scope of all global/function static variable destruction
+FileLogger *g_hidden_file_logger = nullptr;
+FileLogger *GetFileLogger() {
+    if (g_hidden_file_logger == nullptr) {
+        g_hidden_file_logger = new FileLogger();
+    }
+    return g_hidden_file_logger;
+}
+
+fs::path GetLoggingPath(const string &binary_name) {
+    if (!empty(binary_name)) {
+        auto ec = error_code{};
+        auto binary_path = fs::absolute(fs::path(binary_name), ec);
+        if (!ec) {
+            return binary_path.replace_extension("log");
+        }
+    }
+    return fs::current_path() / "app.log";
+}
+
+inline constexpr bool HasHexPrefix(string_view num_value) {
+    return size(num_value) >= 2 && num_value[0] == '0' && (num_value[1] == 'X' || num_value[1] == 'x');
+}
+
+string to_string(std::thread::id thread_id) {
+    string thread_id_str = format(FMT_STRING("{}"), thread_id);
+    if (HasHexPrefix(string_view(data(thread_id_str), size(thread_id_str)))) {
+        thread_id_str = thread_id_str.substr(2);
+    }
+    if (size(thread_id_str) < 16) {
+        thread_id_str = string(16 - size(thread_id_str), '0') + thread_id_str;
+    }
+    return thread_id_str;
+}
+
+string to_string(mmotd::logging::Severity severity) {
+    using namespace mmotd::logging;
+    switch (severity) {
+        case Severity::fatal:
+            return "FATAL";
+            break;
+        case Severity::error:
+            return "ERROR";
+            break;
+        case Severity::warning:
+            return "WARNING";
+            break;
+        case Severity::info:
+            return "INFO";
+            break;
+        case Severity::debug:
+            return "DEBUG";
+            break;
+        case Severity::verbose:
+            return "VERBOSE";
+            break;
+        case Severity::none:
+        default:
+            return "NONE";
+            break;
+    }
+}
+
+fmt::text_style GetSeverityStyle(mmotd::logging::Severity severity) noexcept {
+    using namespace mmotd::logging;
+    auto style = fmt::text_style{};
+    switch (severity) {
+        case Severity::fatal:
+            // fatal -> white on red background
+            style = fmt::text_style(fmt::emphasis::bold) | fmt::fg(fmt::terminal_color::bright_white) |
+                    fmt::bg(fmt::terminal_color::red);
+            break;
+        case Severity::error:
+            // error -> red
+            style = fmt::text_style(fmt::emphasis::bold) | fmt::fg(fmt::terminal_color::red);
+            break;
+        case Severity::warning:
+            // warning -> yellow
+            style = fmt::text_style(fmt::emphasis::bold) | fmt::fg(fmt::terminal_color::bright_yellow);
+            break;
+        case Severity::info:
+            // info -> green
+            style = fmt::text_style(fmt::emphasis::bold) | fmt::fg(fmt::terminal_color::bright_green);
+            break;
+        case Severity::debug:
+            // debug -> orange
+            style = fmt::text_style(fmt::emphasis::bold) | fmt::fg(fmt::color::orange);
+            break;
+        case Severity::verbose:
+            // verbose -> cyan
+            style = fmt::text_style(fmt::emphasis::bold) | fmt::fg(fmt::terminal_color::bright_cyan);
+            break;
+        case Severity::none:
+        default:
+            // none -> grey?
+            style = fmt::text_style(fmt::emphasis::bold) | fmt::fg(fmt::color::gray);
+            break;
+    }
+    return style;
+}
+
+void GetSourceLocationFormattedOutput(fmt::memory_buffer &out,
+                                      mmotd::logging::Severity severity,
+                                      const mmotd::source_location::SourceLocation &source_location) {
+    using namespace mmotd::logging;
+    string thread_id_str = to_string(std::this_thread::get_id());
+    auto now_time_point = date::make_zoned(date::locate_zone("America/Denver"), std::chrono::system_clock::now());
+    string now_str = date::format("%F %H:%M:%S", now_time_point).substr(0, 23);
+    fmt::format_to(std::back_inserter(out),
+                   GetSeverityStyle(severity),
+                   FMT_STRING("{} [{:^7}] [{}] [{}] "),
+                   now_str,
+                   to_string(severity),
+                   thread_id_str,
+                   to_string(source_location));
+}
+
+void GetFormattedOutput(fmt::memory_buffer &out,
+                        mmotd::logging::Severity severity,
+                        fmt::string_view format,
+                        fmt::format_args args) {
+    fmt::vformat_to(std::back_inserter(out), GetSeverityStyle(severity), format, args);
+    if (out.size() != 0 && out.data()[out.size() - 1] != '\n') {
+        out.push_back('\n');
+    }
+}
+
+void WriteLogHeader(const fs::path &binary_path) {
+    auto version_str = mmotd::version::Version::Instance().to_string();
+    auto app_name = binary_path.stem().string();
+    auto date_time = mmotd::chrono::io::to_string(std::chrono::system_clock::now(), "%d-%h-%Y %I:%M%p %Z");
+    auto header = fmt::format(FMT_STRING("{}: {} <{}>"), app_name, version_str, date_time);
+    auto data = fmt::memory_buffer{};
+    fmt::format_to(std::back_inserter(data),
+                   FMT_STRING("┌{0:─^{2}}┐\n"
+                              "│{1: ^{2}}│\n"
+                              "└{0:─^{2}}┘\n\n"),
+                   "",
+                   header,
+                   size(header) + 2);
+    GetFileLogger()->WriteLog(mmotd::logging::Severity::fatal, data, true);
+}
+
+} // namespace
 
 namespace mmotd::logging {
 
-plog::Severity gFileSeverity = plog::verbose;
-plog::Severity gConsoleSeverity = plog::warning;
-
-void DefaultInitializeLogging(const string &filename) {
-    static auto file_appender = plog::RollingFileAppender<plog::TxtFormatter>(filename.c_str(), 5 * 1048576, 3);
-    static auto console_appender = plog::ColorConsoleAppender<plog::TxtFormatter>{};
-    plog::init(gFileSeverity, &file_appender);
-    plog::init<CONSOLE_LOG>(gConsoleSeverity, &console_appender);
+void InitializeLogging(const string &binary_name) {
+    auto logging_path = GetLoggingPath(binary_name);
+    GetFileLogger()->Open(logging_path);
+    WriteLogHeader(binary_name);
 }
 
-// enum Severity
-// {
-//     none = 0,
-//     fatal = 1,
-//     error = 2,
-//     warning = 3,
-//     info = 4,
-//     debug = 5,
-//     verbose = 6
-// };
-
-// mapping from mmotd verbosity to plog severity modes
-static inline constexpr plog::Severity convert_verbosity(Options::Verbosity verbosity) {
-    if (verbosity == Options::Verbosity::Info) {
-        return plog::info;
-    } else if (verbosity == Options::Verbosity::Debug) {
-        return plog::debug;
-    } else if (verbosity == Options::Verbosity::Verbose) {
-        return plog::verbose;
-    } else {
-        // Options::Verbosity::Off or Options::Verbosity::Inavlid
-        return plog::none;
-    }
-}
-
-void UpdateSeverityFilter(Options::Verbosity verbosity) {
-    if (auto severity = std::max(convert_verbosity(verbosity), gFileSeverity); severity != gFileSeverity) {
-        gFileSeverity = severity;
-        auto *file_log = plog::get();
-        file_log->setMaxSeverity(gFileSeverity);
-    }
-    if (auto severity = std::max(convert_verbosity(verbosity), gConsoleSeverity); severity != gConsoleSeverity) {
-        gConsoleSeverity = severity;
-        auto *console_log = plog::get<CONSOLE_LOG>();
-        console_log->setMaxSeverity(gConsoleSeverity);
-    }
+void LogInternal(const mmotd::source_location::SourceLocation &source_location,
+                 Severity severity,
+                 fmt::string_view format,
+                 fmt::format_args args) {
+    auto data = fmt::memory_buffer{};
+    GetSourceLocationFormattedOutput(data, severity, source_location);
+    GetFormattedOutput(data, severity, format, args);
+    GetFileLogger()->WriteLog(severity, data);
 }
 
 } // namespace mmotd::logging

--- a/common/src/logging.cpp
+++ b/common/src/logging.cpp
@@ -33,8 +33,6 @@ mmotd::logging::Severity LOGGING_SEVERITY = mmotd::logging::Severity::verbose;
 
 namespace {
 
-static std::mutex LOGGER_IO_MUTEX;
-
 class FileLogger {
 public:
     FileLogger() = default;

--- a/common/src/mac_address.cpp
+++ b/common/src/mac_address.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/assertion/include/assertion.h"
+#include "common/include/logging.h"
 #include "common/include/mac_address.h"
 
 #include <cstring>
@@ -9,7 +10,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using namespace std;
 using boost::numeric_cast;

--- a/common/src/source_location.cpp
+++ b/common/src/source_location.cpp
@@ -1,0 +1,33 @@
+// vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/source_location.h"
+#include "common/include/source_location_common.h"
+
+#include <fmt/format.h>
+
+using namespace std;
+
+namespace mmotd::source_location {
+
+SourceLocation::SourceLocation(const char *file, long line, const char *function) :
+    line_(static_cast<uint32_t>(line)),
+    // column_(0ul),
+    file_name_(TrimFileName(file)),
+    function_name_(TrimFunction(function, FunctionArgStrategy::replace, FunctionReturnStrategy::remove)) {
+}
+
+// 2021-04-22 22:19:30.397 VERB  [412078] [output_frame.cpp@mmotd::results::Frame::RemoveEmptyRows#179] inspecting row: 68646671, empty rows: 68646651
+// to_string returns: `[output_frame.cpp@mmotd::results::Frame::RemoveEmptyRows#179]` in the best case scenario
+//           returns: `[]` in the worst case scenario
+string SourceLocation::to_string() const {
+    auto result = string{};
+    result = file_name_;
+    result = format(FMT_STRING("{}{}{}"), result, (empty(result) ? "" : "@"), function_name_);
+    result = format(FMT_STRING("{}{}{}"), result, (line_ != 0 ? "#" : ""), (line_ != 0 ? ::to_string(line_) : ""));
+    return result;
+}
+
+string to_string(const SourceLocation &source_location) {
+    return source_location.to_string();
+}
+
+} // namespace mmotd::source_location

--- a/common/src/source_location_common.cpp
+++ b/common/src/source_location_common.cpp
@@ -1,0 +1,107 @@
+// vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/source_location_common.h"
+
+#include <string>
+#include <string_view>
+
+#include <fmt/format.h>
+
+using fmt::format;
+using namespace std;
+
+namespace {
+
+static constexpr const char *UNKNOWN_FILE = "<file>";
+static constexpr const char *UNKNOWN_FUNCTION = "<...>";
+
+size_t GetAnonymousNamespaceIndexEnd(string function) noexcept {
+    static constexpr auto anonymous_ns1 = "(anonymous namespace)::"sv;
+    static constexpr auto anonymous_ns2 = "{anonymous}::"sv;
+    if (auto index1 = function.find(anonymous_ns1); index1 != string::npos) {
+        return index1 + size(anonymous_ns1);
+    } else if (auto index2 = function.find(anonymous_ns2); index2 != string::npos) {
+        return index2 + size(anonymous_ns2);
+    } else {
+        return string::npos;
+    }
+}
+
+pair<size_t, size_t> FindParens(string backtrace_detail) {
+    auto open_paren = backtrace_detail.rfind('(');
+    auto close_paren = backtrace_detail.find(')', open_paren);
+    return {open_paren, close_paren};
+}
+
+} // namespace
+
+namespace mmotd::source_location {
+
+string TrimFileName(const char *file) noexcept {
+    auto file_str = file == nullptr ? string{UNKNOWN_FILE} : string(file);
+    if (auto index = file_str.find_last_of('/'); index != string::npos) {
+        file_str = file_str.substr(index + 1);
+    }
+    return file_str;
+}
+
+// bool (anonymous namespace)::IsInterfaceActive(...)
+// bool (anonymous namespace)::IsInterfaceActive(...)
+// bool (anonymous namespace)::IsInterfaceActive(...)
+// optional<fmt::text_style> (anonymous namespace)::GetTerminalPlainColor(...)
+// optional<fmt::text_style> (anonymous namespace)::GetTerminalPlainColor(...)
+// static optional<mmotd::information::Information> mmotd::results::TemplateString::FindInformation(...)
+// static optional<std::__1::string> mmotd::results::TemplateString::GetInformationValue(...)
+// static optional<mmotd::information::Information> mmotd::results::TemplateString::FindInformation(...)
+// static optional<std::__1::string> mmotd::results::TemplateString::GetInformationValue(...)
+
+string
+TrimFunction(const char *function, FunctionArgStrategy arg_strategy, FunctionReturnStrategy return_strategy) noexcept {
+    auto function_str = function == nullptr ? string{UNKNOWN_FUNCTION} : string(function);
+    if (arg_strategy == FunctionArgStrategy::remove) {
+        auto index = function_str.find('(');
+        function_str = function_str.substr(0, index);
+    } else if (arg_strategy == FunctionArgStrategy::replace) {
+        function_str = StripFunctionArgs(function_str);
+    }
+    if (return_strategy == FunctionReturnStrategy::remove) {
+        function_str = StripNamespaces(StripFunctionReturn(StripAnonymousNamespace(function_str)));
+    }
+    return function_str;
+}
+
+string StripFunctionReturn(string function) noexcept {
+    if (auto index = function.rfind(' '); index != string::npos) {
+        return function.substr(index + 1);
+    } else {
+        return function;
+    }
+}
+
+string StripAnonymousNamespace(string function) noexcept {
+    if (auto index = GetAnonymousNamespaceIndexEnd(function); index != string::npos) {
+        return function.substr(index);
+    } else {
+        return function;
+    }
+}
+
+string StripNamespaces(string function) noexcept {
+    if (auto index = function.rfind("::"); index != string::npos) {
+        if (auto sub_index = function.rfind("::", index - 1); sub_index != string::npos) {
+            return function.substr(sub_index + 2);
+        }
+    }
+    return function;
+}
+
+string StripFunctionArgs(string function) noexcept {
+    auto [open_paren, close_paren] = FindParens(function);
+    if (open_paren != string::npos && close_paren != string::npos && open_paren + 1 != close_paren) {
+        function = format(FMT_STRING("{}(...){}"),
+                          string{begin(function), begin(function) + open_paren},
+                          string{begin(function) + close_paren + 1, end(function)});
+    }
+    return function;
+}
+
+} // namespace mmotd::source_location

--- a/common/src/version.cpp
+++ b/common/src/version.cpp
@@ -1,3 +1,4 @@
+#include "common/include/logging.h"
 #include "common/include/version.h"
 #include "common/include/version_number.h"
 
@@ -12,7 +13,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using namespace std;
@@ -51,9 +51,7 @@ int32_t FromString(string_view str) {
     auto result = int32_t{0};
     auto [ptr, ec] = std::from_chars(begin(str), end(str), result);
     if (ec != std::errc{}) {
-        PLOG_ERROR << format(FMT_STRING("unable to convert {} into an integer, {}"),
-                             str,
-                             make_error_code(ec).message());
+        LOG_ERROR("unable to convert {} into an integer, {}", str, make_error_code(ec).message());
     }
     return result;
 }
@@ -70,16 +68,16 @@ optional<version> version::from_string(string_view str) {
       (?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$)"_verbose; // build number
 
     const auto &pattern = REGEX_SEMVER_PATTERN;
-    PLOG_INFO << format(FMT_STRING("pattern should now match verbose mode \"{}\""), pattern);
+    // LOG_INFO("pattern should now match verbose mode \"{}\"", pattern);
     auto semver_regex = regex(pattern);
     auto matches = std::cmatch{};
     if (!std::regex_match(begin(str), end(str), matches, semver_regex)) {
-        PLOG_ERROR << format(FMT_STRING("version {} is not a semver compliant version string"), str);
+        LOG_ERROR("version {} is not a semver compliant version string", str);
         return nullopt;
     }
 
     if (matches.size() < 3) {
-        PLOG_ERROR << "semver regex succeeded but there were not 3 sub-matches (major, minor, patch)";
+        LOG_ERROR("semver regex succeeded but there were not 3 sub-matches (major, minor, patch)");
         return nullopt;
     }
 
@@ -121,7 +119,7 @@ const Version &Version::Instance() {
 Version::Version(string_view str) : version_() {
     auto version_wrapper = mmotd::semver::version::from_string(str);
     if (!version_wrapper) {
-        PLOG_ERROR << format(FMT_STRING("unable to create semver version from {} version string"), str);
+        LOG_ERROR("unable to create semver version from {} version string", str);
     }
     version_ = make_unique<mmotd::semver::version>(version_wrapper ? *version_wrapper : mmotd::semver::version{});
 }

--- a/lib/src/boot_time.cpp
+++ b/lib/src/boot_time.cpp
@@ -2,6 +2,7 @@
 #include "common/include/chrono_io.h"
 #include "common/include/information.h"
 #include "common/include/information_definitions.h"
+#include "common/include/logging.h"
 #include "common/include/posix_error.h"
 #include "lib/include/boot_time.h"
 #include "lib/include/computer_information.h"
@@ -16,7 +17,6 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using namespace std;

--- a/lib/src/computer_information.cpp
+++ b/lib/src/computer_information.cpp
@@ -2,6 +2,7 @@
 #include "common/include/algorithm.h"
 #include "common/include/information_definitions.h"
 #include "common/include/information_objects.h"
+#include "common/include/logging.h"
 #include "lib/include/computer_information.h"
 #include "lib/include/information_provider.h"
 
@@ -12,7 +13,6 @@
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using namespace std;
 using fmt::format;
@@ -44,7 +44,7 @@ void ComputerInformation::SetInformationProviders() {
     auto &creators = GetInformationProviderCreators();
     information_providers_.resize(creators.size());
     transform(begin(creators), end(creators), begin(information_providers_), [](auto &creator) { return creator(); });
-    PLOG_INFO << format(FMT_STRING("created {} information providers"), information_providers_.size());
+    LOG_INFO("created {} information providers", information_providers_.size());
 }
 
 bool RegisterInformationProvider(InformationProviderCreator creator) {

--- a/lib/src/file_system.cpp
+++ b/lib/src/file_system.cpp
@@ -1,12 +1,12 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/human_size.h"
+#include "common/include/logging.h"
 #include "lib/include/computer_information.h"
 #include "lib/include/file_system.h"
 
 #include <filesystem>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using namespace std;
@@ -23,7 +23,7 @@ bool FileSystem::FindInformation() {
     auto ec = error_code{};
     auto root_fs = std::filesystem::space("/", ec);
     if (ec) {
-        PLOG_ERROR << format(FMT_STRING("getting fs::space on root file system, details: {}"), ec.message());
+        LOG_ERROR("getting fs::space on root file system, details: {}", ec.message());
         return false;
     }
 

--- a/lib/src/http_request.cpp
+++ b/lib/src/http_request.cpp
@@ -1,4 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/logging.h"
 #include "lib/include/http_request.h"
 
 #include <boost/asio/connect.hpp>
@@ -12,7 +13,6 @@
 #include <boost/certify/https_verification.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 namespace beast = boost::beast;
 namespace asio = boost::asio;
@@ -163,7 +163,7 @@ optional<string> HttpClient::MakeRequestImpl() {
     auto response = Request(*stream);
 
     auto response_str = response.body();
-    PLOG_INFO << format(FMT_STRING("response from {}:{}{}\n{}"), host_, port_, path_, response_str);
+    LOG_INFO("response from {}:{}{}\n{}", host_, port_, path_, response_str);
     CloseStream(*stream);
 
     return make_optional(response_str);

--- a/lib/src/information_provider.cpp
+++ b/lib/src/information_provider.cpp
@@ -32,13 +32,10 @@ bool InformationProvider::LookupInformation() {
         return FindInformation();
     } catch (boost::exception &ex) {
         auto diag = boost::diagnostic_information(ex);
-        auto error_str = format(FMT_STRING("caught boost::exception in LookupInformation: {}"), diag);
-        PLOG_ERROR << error_str;
+        LOG_ERROR("caught boost::exception in LookupInformation: {}", diag);
     } catch (const std::exception &ex) {
         auto diag = boost::diagnostic_information(ex);
-        auto error_str =
-            format(FMT_STRING("caught std::exception in LookupInformation: {}"), empty(diag) ? ex.what() : data(diag));
-        PLOG_ERROR << error_str;
+        LOG_ERROR("caught std::exception in LookupInformation: {}", empty(diag) ? ex.what() : data(diag));
     }
     return false;
 }

--- a/lib/src/memory.cpp
+++ b/lib/src/memory.cpp
@@ -1,12 +1,12 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/human_size.h"
+#include "common/include/logging.h"
 #include "common/include/posix_error.h"
 #include "lib/include/computer_information.h"
 #include "lib/include/memory.h"
 #include "lib/include/platform/memory.h"
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 #include <scope_guard.hpp>
 
 using fmt::format;

--- a/lib/src/package_management.cpp
+++ b/lib/src/package_management.cpp
@@ -1,4 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/logging.h"
 #include "lib/include/computer_information.h"
 #include "lib/include/package_management.h"
 #include "lib/include/platform/package_management.h"
@@ -7,7 +8,6 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using namespace std;
@@ -24,14 +24,14 @@ bool PackageManagement::FindInformation() {
     if (!empty(update_details)) {
         auto update_details_info = GetInfoTemplate(InformationId::ID_PACKAGE_MANAGEMENT_UPDATE_DETAILS);
         update_details_info.SetValueArgs(update_details);
-        PLOG_VERBOSE << format(FMT_STRING("set the value of package management update details: {}"), update_details);
+        LOG_VERBOSE("set the value of package management update details: {}", update_details);
         AddInformation(update_details_info);
     }
     auto reboot_required = platform::package_management::GetRebootRequired();
     if (!empty(reboot_required)) {
         auto reboot_required_info = GetInfoTemplate(InformationId::ID_PACKAGE_MANAGEMENT_REBOOT_REQUIRED);
         reboot_required_info.SetValueArgs(reboot_required);
-        PLOG_VERBOSE << format(FMT_STRING("set the value of package management reboot required: {}"), reboot_required);
+        LOG_VERBOSE("set the value of package management reboot required: {}", reboot_required);
         AddInformation(reboot_required_info);
     }
     return true;

--- a/lib/src/platform/darwin/boot_time.cpp
+++ b/lib/src/platform/darwin/boot_time.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/chrono_io.h"
+#include "common/include/logging.h"
 #include "common/include/posix_error.h"
 
 #include <chrono>
@@ -11,7 +12,6 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 #include <sys/sysctl.h>
 
@@ -27,17 +27,16 @@ optional<std::chrono::system_clock::time_point> GetBootTime() {
     size_t result_len = sizeof(timeval);
 
     if (sysctl(mib, 2, &result, &result_len, NULL, 0) == -1) {
-        auto error_str = string{"sysctl(KERN_BOOTTIME) syscall failed"};
+        auto error_str = string{};
         if (auto errno_str = mmotd::error::posix_error::to_string(); !errno_str.empty()) {
-            error_str += format(FMT_STRING(", details: {}"), errno_str);
+            error_str = format(FMT_STRING(", details: {}"), errno_str);
         }
-        PLOG_ERROR << error_str;
+        LOG_ERROR("sysctl(KERN_BOOTTIME) syscall failed{}", error_str);
         return make_optional(std::chrono::system_clock::now());
     }
 
     auto boot_time_point = std::chrono::system_clock::from_time_t(result.tv_sec);
-    PLOG_VERBOSE << format(FMT_STRING("sysctl(KERN_BOOTTIME): {}"),
-                           to_string(boot_time_point, "%d-%h-%Y %I:%M:%S%p %Z"));
+    LOG_VERBOSE("sysctl(KERN_BOOTTIME): {}", to_string(boot_time_point, "%d-%h-%Y %I:%M:%S%p %Z"));
     return make_optional(boot_time_point);
 }
 

--- a/lib/src/platform/darwin/lastlog.cpp
+++ b/lib/src/platform/darwin/lastlog.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/chrono_io.h"
+#include "common/include/logging.h"
 #include "lib/include/platform/lastlog.h"
 #include "lib/include/platform/user_accounting_database.h"
 
@@ -10,7 +11,6 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 using mmotd::chrono::io::to_string;
 
 using fmt::format;
@@ -24,14 +24,12 @@ LastLoginDetails GetLastLogDetails() {
 
     auto entries = GetDbEntries<ENTRY_TYPE::User>();
     auto user_info = GetUserInformation();
-    PLOG_VERBOSE << format(FMT_STRING("last login: entries size: {}, user info: {}"),
-                           entries.size(),
-                           user_info.empty() ? "empty" : user_info.username);
+    LOG_VERBOSE("last login: entries size: {}, user info: {}",
+                entries.size(),
+                user_info.empty() ? "empty" : user_info.username);
 
     if (entries.empty() || user_info.empty()) {
-        PLOG_ERROR << format(FMT_STRING("last login: entries size: {}, user info: {}"),
-                             entries.size(),
-                             user_info.empty() ? "empty" : "valid");
+        LOG_ERROR("last login: entries size: {}, user info: {}", entries.size(), user_info.empty() ? "empty" : "valid");
         return LastLoginDetails{};
     }
 
@@ -39,12 +37,12 @@ LastLoginDetails GetLastLogDetails() {
         min_element(begin(entries), end(entries), [](const auto &a, const auto &b) { return a.seconds < b.seconds; });
 
     if (i == end(entries)) {
-        PLOG_ERROR << "last login: unable to find a user process to use";
+        LOG_ERROR("last login: unable to find a user process to use");
         return LastLoginDetails{};
     }
 
     const auto &entry = *i;
-    PLOG_VERBOSE << format(FMT_STRING("last log: found {}"), entry.to_string());
+    LOG_VERBOSE("last log: found {}", entry.to_string());
 
     auto summary = format(FMT_STRING("{} logged into {}"), entry.user, entry.device_name);
     if (!entry.hostname.empty()) {
@@ -54,9 +52,9 @@ LastLoginDetails GetLastLogDetails() {
     auto log_in_time = std::chrono::system_clock::from_time_t(entry.seconds);
     auto details = LastLoginDetails{summary, log_in_time, std::chrono::system_clock::time_point{}};
 
-    PLOG_VERBOSE << format(FMT_STRING("last login: {}"), details.summary);
-    PLOG_VERBOSE << format(FMT_STRING("last log in: {}"), to_string(details.log_in, "%d-%h-%Y %I:%M:%S%p %Z"));
-    PLOG_VERBOSE << "last log out: still logged in";
+    LOG_VERBOSE("last login: {}", details.summary);
+    LOG_VERBOSE("last log in: {}", to_string(details.log_in, "%d-%h-%Y %I:%M:%S%p %Z"));
+    LOG_VERBOSE("last log out: still logged in");
 
     return details;
 }

--- a/lib/src/platform/darwin/load_average.cpp
+++ b/lib/src/platform/darwin/load_average.cpp
@@ -1,14 +1,15 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/logging.h"
 #include "lib/include/platform/load_average.h"
 
 #include <ctime>
 #include <optional>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 #include <sys/sysctl.h>
 #include <time.h>
+#include <unistd.h>
 
 using fmt::format;
 using namespace std;
@@ -18,10 +19,10 @@ namespace {
 optional<int32_t> GetCpuCount() {
     auto cpu_count = sysconf(_SC_NPROCESSORS_ONLN);
     if (cpu_count == -1) {
-        PLOG_ERROR << "sysconf returned -1 calling get processor count _SC_NPROCESSORS_ONLN";
+        LOG_ERROR("sysconf returned -1 calling get processor count _SC_NPROCESSORS_ONLN");
         return nullopt;
     } else {
-        PLOG_INFO << format(FMT_STRING("sysconf for _SC_NPROCESSORS_ONLN returned {} processors"), cpu_count);
+        LOG_INFO("sysconf for _SC_NPROCESSORS_ONLN returned {} processors", cpu_count);
         return make_optional(cpu_count);
     }
 }
@@ -30,13 +31,13 @@ optional<double> GetSystemLoadAverage() {
     auto load = loadavg{};
     auto load_size = sizeof(load);
     if (sysctlbyname("vm.loadavg", &load, &load_size, NULL, 0) == -1) {
-        PLOG_ERROR << "sysctlbyname returned -1 calling vm.loadavg";
+        LOG_ERROR("sysctlbyname returned -1 calling vm.loadavg");
         return nullopt;
     } else {
-        PLOG_INFO << format(FMT_STRING("sysctlbyname returned 1 min: {}, 5 min: {}, 15 min: {}"),
-                            load.ldavg[0] / static_cast<double>(load.fscale),
-                            load.ldavg[1] / static_cast<double>(load.fscale),
-                            load.ldavg[2] / static_cast<double>(load.fscale));
+        LOG_INFO("sysctlbyname returned 1 min: {}, 5 min: {}, 15 min: {}",
+                 load.ldavg[0] / static_cast<double>(load.fscale),
+                 load.ldavg[1] / static_cast<double>(load.fscale),
+                 load.ldavg[2] / static_cast<double>(load.fscale));
         return make_optional(load.ldavg[0] / static_cast<double>(load.fscale));
     }
 }

--- a/lib/src/platform/darwin/memory.cpp
+++ b/lib/src/platform/darwin/memory.cpp
@@ -2,6 +2,7 @@
 #include "common/include/human_size.h"
 #include "common/include/information_definitions.h"
 #include "common/include/information_objects.h"
+#include "common/include/logging.h"
 #include "common/include/posix_error.h"
 #include "lib/include/platform/memory.h"
 
@@ -11,7 +12,6 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 #include <scope_guard.hpp>
 
 #include <mach/mach.h>
@@ -35,7 +35,7 @@ bool GetVmStat(vm_statistics_data_t *vmstat) {
 
     auto retval = host_statistics(mach_port, HOST_VM_INFO, reinterpret_cast<host_info_t>(vmstat), &count);
     if (retval != KERN_SUCCESS) {
-        PLOG_ERROR << format(FMT_STRING("when calling host_statistics, details: {}"), mach_error_string(retval));
+        LOG_ERROR("when calling host_statistics, details: {}", mach_error_string(retval));
         return false;
     }
 
@@ -47,11 +47,11 @@ optional<uint64_t> GetTotalMemory() {
     auto total = uint64_t{0};
     auto len = sizeof(uint64_t);
     if (sysctl(mib, 2, &total, &len, NULL, 0) == -1) {
-        auto error_str = string{"sysctl(HW_MEMSIZE) syscall failed"};
+        auto error_str = string{};
         if (auto errno_str = mmotd::error::posix_error::to_string(); !errno_str.empty()) {
-            error_str += format(FMT_STRING(", details: {}"), errno_str);
+            error_str = format(FMT_STRING(", details: {}"), errno_str);
         }
-        PLOG_ERROR << error_str;
+        LOG_ERROR("sysctl(HW_MEMSIZE) syscall failed{}", error_str);
         return nullopt;
     }
     return make_optional(total);
@@ -71,43 +71,39 @@ optional<mmotd::platform::MemoryDetails> GetMemoryUsage() {
 
     const auto pagesize = getpagesize();
 
-    PLOG_VERBOSE << format(FMT_STRING("pagesize: {}"), pagesize);
-    PLOG_VERBOSE << format(FMT_STRING("active count: {}, {}"),
-                           to_human_size(vm_statistics_data.active_count),
-                           vm_statistics_data.active_count);
-    PLOG_VERBOSE << format(FMT_STRING("inactive count: {}, {}"),
-                           to_human_size(vm_statistics_data.inactive_count),
-                           vm_statistics_data.inactive_count);
-    PLOG_VERBOSE << format(FMT_STRING("wire count: {}, {}"),
-                           to_human_size(vm_statistics_data.wire_count),
-                           vm_statistics_data.wire_count);
-    PLOG_VERBOSE << format(FMT_STRING("free count: {}, {}"),
-                           to_human_size(vm_statistics_data.free_count),
-                           vm_statistics_data.free_count);
-    PLOG_VERBOSE << format(FMT_STRING("speculative count: {}, {}"),
-                           to_human_size(vm_statistics_data.speculative_count),
-                           vm_statistics_data.speculative_count);
+    LOG_VERBOSE("pagesize: {}", pagesize);
+    LOG_VERBOSE("active count: {}, {}",
+                to_human_size(vm_statistics_data.active_count),
+                vm_statistics_data.active_count);
+    LOG_VERBOSE("inactive count: {}, {}",
+                to_human_size(vm_statistics_data.inactive_count),
+                vm_statistics_data.inactive_count);
+    LOG_VERBOSE("wire count: {}, {}", to_human_size(vm_statistics_data.wire_count), vm_statistics_data.wire_count);
+    LOG_VERBOSE("free count: {}, {}", to_human_size(vm_statistics_data.free_count), vm_statistics_data.free_count);
+    LOG_VERBOSE("speculative count: {}, {}",
+                to_human_size(vm_statistics_data.speculative_count),
+                vm_statistics_data.speculative_count);
 
     auto active = static_cast<uint64_t>(vm_statistics_data.active_count) * pagesize;
     auto inactive = static_cast<uint64_t>(vm_statistics_data.inactive_count) * pagesize;
     auto wired = static_cast<uint64_t>(vm_statistics_data.wire_count) * pagesize;
     auto free = static_cast<uint64_t>(vm_statistics_data.free_count) * pagesize;
     auto speculative = static_cast<uint64_t>(vm_statistics_data.speculative_count) * pagesize;
-    PLOG_VERBOSE << format(FMT_STRING("active: {}, {}"), to_human_size(active), active);
-    PLOG_VERBOSE << format(FMT_STRING("inactive: {}, {}"), to_human_size(inactive), inactive);
-    PLOG_VERBOSE << format(FMT_STRING("wired: {}, {}"), to_human_size(wired), wired);
-    PLOG_VERBOSE << format(FMT_STRING("free: {}, {}"), to_human_size(free), free);
-    PLOG_VERBOSE << format(FMT_STRING("speculative: {}, {}"), to_human_size(speculative), speculative);
+    LOG_VERBOSE("active: {}, {}", to_human_size(active), active);
+    LOG_VERBOSE("inactive: {}, {}", to_human_size(inactive), inactive);
+    LOG_VERBOSE("wired: {}, {}", to_human_size(wired), wired);
+    LOG_VERBOSE("free: {}, {}", to_human_size(free), free);
+    LOG_VERBOSE("speculative: {}, {}", to_human_size(speculative), speculative);
 
     auto avail = inactive + free;
     auto used = active + wired;
     free = speculative < free ? free - speculative : 0;
-    PLOG_VERBOSE << format(FMT_STRING("avail = inactive + free: {}, {}"), to_human_size(avail), avail);
-    PLOG_VERBOSE << format(FMT_STRING("used = active + wired: {}, {}"), to_human_size(used), used);
-    PLOG_VERBOSE << format(FMT_STRING("free = free - speculative: {}, {}"), to_human_size(free), free);
+    LOG_VERBOSE("avail = inactive + free: {}, {}", to_human_size(avail), avail);
+    LOG_VERBOSE("used = active + wired: {}, {}", to_human_size(used), used);
+    LOG_VERBOSE("free = free - speculative: {}, {}", to_human_size(free), free);
 
     auto percent = (static_cast<double>(total - avail) / static_cast<double>(total)) * 100.0;
-    PLOG_VERBOSE << format(FMT_STRING("percent used: {:.01f}"), percent);
+    LOG_VERBOSE("percent used: {:.01f}", percent);
 
     return make_optional(mmotd::platform::MemoryDetails{total, avail, percent, used, free, active, inactive, wired});
 }

--- a/lib/src/platform/darwin/package_management.cpp
+++ b/lib/src/platform/darwin/package_management.cpp
@@ -1,21 +1,20 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/logging.h"
 #include "lib/include/platform/package_management.h"
 
 #include <string>
-
-#include <plog/Log.h>
 
 using namespace std;
 
 namespace mmotd::platform::package_management {
 
 string GetUpdateDetails() {
-    PLOG_VERBOSE << "[darwin] getting package management update details";
+    LOG_VERBOSE("[darwin] getting package management update details");
     return string{};
 }
 
 string GetRebootRequired() {
-    PLOG_VERBOSE << "[darwin] getting package management reboot required";
+    LOG_VERBOSE("[darwin] getting package management reboot required");
     return string{};
 }
 

--- a/lib/src/platform/darwin/processes.cpp
+++ b/lib/src/platform/darwin/processes.cpp
@@ -1,4 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/logging.h"
 #include "common/include/posix_error.h"
 #include "lib/include/platform/processes.h"
 
@@ -6,7 +7,6 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 #include <sys/sysctl.h>
 
@@ -19,11 +19,10 @@ optional<vector<int32_t>> GetProcessesInfo() {
     int mib[3] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL};
     int count = 8; // arbitrary count
     for (int index = 0; index < count; ++index) {
-        PLOG_VERBOSE << format(FMT_STRING("{}. attempting to get process list"), index);
+        LOG_VERBOSE("{}. attempting to get process list", index);
         auto size = size_t{0};
         if (sysctl(mib, 3, NULL, &size, NULL, 0) == -1) {
-            PLOG_ERROR << format(FMT_STRING("sysctl(KERN_PROC_ALL) failed, details: {}"),
-                                 mmotd::error::posix_error::to_string());
+            LOG_ERROR("sysctl(KERN_PROC_ALL) failed, details: {}", mmotd::error::posix_error::to_string());
             break;
         }
 
@@ -31,20 +30,18 @@ optional<vector<int32_t>> GetProcessesInfo() {
         auto buffer = vector<uint8_t>(size, 0);
         if (sysctl(mib, 3, buffer.data(), &size, NULL, 0) == -1) {
             if (errno == ENOMEM) {
-                PLOG_ERROR << format(
-                    FMT_STRING("sysctl(KERN_PROC_ALL) failed with ENOMEM, attempting allocation again"));
+                LOG_ERROR("sysctl(KERN_PROC_ALL) failed with ENOMEM, attempting allocation again");
                 continue;
             }
-            PLOG_ERROR << format(FMT_STRING("sysctl(KERN_PROC_ALL) failed, details: {}"),
-                                 mmotd::error::posix_error::to_string());
+            LOG_ERROR("sysctl(KERN_PROC_ALL) failed, details: {}", mmotd::error::posix_error::to_string());
             break;
         }
 
         const kinfo_proc *proc_list = reinterpret_cast<const kinfo_proc *>(buffer.data());
         auto proc_count = static_cast<size_t>(size / sizeof(kinfo_proc));
-        PLOG_INFO << format(FMT_STRING("sysctl(KERN_PROC_ALL) discovered {} processes"), proc_count);
+        LOG_INFO("sysctl(KERN_PROC_ALL) discovered {} processes", proc_count);
         if (proc_count == 0) {
-            PLOG_ERROR << format(FMT_STRING("sysctl(KERN_PROC_ALL) no PID's were returned"));
+            LOG_ERROR("sysctl(KERN_PROC_ALL) no PID's were returned");
             break;
         }
 
@@ -68,11 +65,6 @@ optional<size_t> GetProcessCount() {
     if (!process_ids) {
         return nullopt;
     }
-    //auto process_ids_str = string{};
-    //for (const auto id : process_ids) {
-    //    process_ids_str += format(FMT_STRING("{}{}", process_ids_str.empty() ? "" : ", "), id);
-    //}
-    //PLOG_VERBOSE << format(FMT_STRING("found process ids: {}"), process_ids_str);
     return make_optional((*process_ids).size());
 }
 

--- a/lib/src/platform/darwin/system_information.cpp
+++ b/lib/src/platform/darwin/system_information.cpp
@@ -1,4 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/logging.h"
 #include "common/include/posix_error.h"
 #include "lib/include/platform/system_information.h"
 #include "lib/include/system_details.h"
@@ -11,7 +12,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 #include <sys/sysctl.h>
 #include <sys/utsname.h>
@@ -69,8 +69,7 @@ optional<tuple<int, int, int>> GetOsVersion() {
     size_t miblen = 512;
     if (sysctlnametomib("kern.osproductversion", mib, &miblen) == -1) {
         auto error_str = mmotd::error::posix_error::to_string();
-        PLOG_ERROR << format(FMT_STRING("error calling sysctlnametomib with kern.osproductversion, details: {}"),
-                             error_str);
+        LOG_ERROR("error calling sysctlnametomib with kern.osproductversion, details: {}", error_str);
         return nullopt;
     }
     char version[512] = {0};
@@ -78,7 +77,7 @@ optional<tuple<int, int, int>> GetOsVersion() {
     size_t length = sizeof(long long);
     if (sysctl(mib, 2, version, &length, NULL, 0) == -1) {
         auto error_str = mmotd::error::posix_error::to_string();
-        PLOG_ERROR << format(FMT_STRING("error calling sysctl with kern.osproductversion, details: {}"), error_str);
+        LOG_ERROR("error calling sysctl with kern.osproductversion, details: {}", error_str);
         return nullopt;
     }
     auto versions = vector<string>{};
@@ -99,9 +98,9 @@ optional<tuple<int, int, int>> GetOsVersion() {
 optional<KernelDetails> GetKernelDetails() {
     struct utsname buf = {};
     int retval = uname(&buf);
-    PLOG_DEBUG << format(FMT_STRING("uname returned {} [{}]"), retval, retval == 0 ? "success" : "failed");
+    LOG_DEBUG("uname returned {} [{}]", retval, retval == 0 ? "success" : "failed");
     if (retval != 0) {
-        PLOG_ERROR << format(FMT_STRING("uname failed with return code '{}'"), retval);
+        LOG_ERROR("uname failed with return code '{}'", retval);
         return nullopt;
     }
 
@@ -111,11 +110,11 @@ optional<KernelDetails> GetKernelDetails() {
     auto version = string(buf.version);
     auto machine = string(buf.machine);
 
-    PLOG_DEBUG << "sys name: " << sys_name;
-    PLOG_DEBUG << "node name: " << node_name;
-    PLOG_DEBUG << "release: " << release;
-    PLOG_DEBUG << "version: " << version;
-    PLOG_DEBUG << "machine: " << machine;
+    LOG_DEBUG("sys name: {}", sys_name);
+    LOG_DEBUG("node name: {}", node_name);
+    LOG_DEBUG("release: {}", release);
+    LOG_DEBUG("version: {}", version);
+    LOG_DEBUG("machine: {}", machine);
 
     return KernelDetails::from_string(sys_name, node_name, release, version, machine);
 }

--- a/lib/src/platform/linux/boot_time.cpp
+++ b/lib/src/platform/linux/boot_time.cpp
@@ -1,6 +1,7 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/chrono_io.h"
 #include "common/include/iostream_error.h"
+#include "common/include/logging.h"
 
 #include <chrono>
 #include <fstream>
@@ -8,7 +9,6 @@
 #include <string>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using namespace std;
 using fmt::format;
@@ -25,9 +25,9 @@ optional<std::chrono::system_clock::time_point> GetBootTime() {
     uptime_file.open(UPTIME_FILENAME, ios_base::in);
 
     if (!uptime_file.is_open() || uptime_file.fail() || uptime_file.bad()) {
-        PLOG_ERROR << format(FMT_STRING("unable to open {} for reading, {}"),
-                             UPTIME_FILENAME,
-                             mmotd::error::ios_flags::to_string(uptime_file));
+        LOG_ERROR("unable to open {} for reading, {}",
+                  UPTIME_FILENAME,
+                  mmotd::error::ios_flags::to_string(uptime_file));
         return make_optional(std::chrono::system_clock::now());
     }
     auto uptime = double{};

--- a/lib/src/platform/linux/lastlog.cpp
+++ b/lib/src/platform/linux/lastlog.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/chrono_io.h"
+#include "common/include/logging.h"
 #include "lib/include/platform/lastlog.h"
 #include "lib/include/platform/user_accounting_database.h"
 
@@ -11,7 +12,6 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using namespace std;
@@ -25,14 +25,12 @@ LastLoginDetails GetLastLogDetails() {
 
     auto entries = GetDbEntries<ENTRY_TYPE::User>();
     auto user_info = GetUserInformation();
-    PLOG_VERBOSE << format(FMT_STRING("last login: entries size: {}, user info: {}"),
-                           entries.size(),
-                           user_info.empty() ? "empty" : user_info.username);
+    LOG_VERBOSE("last login: entries size: {}, user info: {}",
+                entries.size(),
+                user_info.empty() ? "empty" : user_info.username);
 
     if (entries.empty() || user_info.empty()) {
-        PLOG_ERROR << format(FMT_STRING("last login: entries size: {}, user info: {}"),
-                             entries.size(),
-                             user_info.empty() ? "empty" : "valid");
+        LOG_ERROR("last login: entries size: {}, user info: {}", entries.size(), user_info.empty() ? "empty" : "valid");
         return LastLoginDetails{};
     }
 
@@ -40,12 +38,12 @@ LastLoginDetails GetLastLogDetails() {
         min_element(begin(entries), end(entries), [](const auto &a, const auto &b) { return a.seconds < b.seconds; });
 
     if (i == end(entries)) {
-        PLOG_ERROR << "last login: unable to find a user process to use";
+        LOG_ERROR("last login: unable to find a user process to use");
         return LastLoginDetails{};
     }
 
     const auto &entry = *i;
-    PLOG_VERBOSE << format(FMT_STRING("last log: found {}"), entry.to_string());
+    LOG_VERBOSE("last log: found {}", entry.to_string());
 
     auto summary = format(FMT_STRING("{} logged into {}"), entry.user, entry.device_name);
     if (!entry.hostname.empty()) {
@@ -55,9 +53,9 @@ LastLoginDetails GetLastLogDetails() {
     auto log_in_time = std::chrono::system_clock::from_time_t(entry.seconds);
     auto details = LastLoginDetails{summary, log_in_time, std::chrono::system_clock::time_point{}};
 
-    PLOG_VERBOSE << format(FMT_STRING("last login: {}"), details.summary);
-    PLOG_VERBOSE << format(FMT_STRING("last log in: {}"), to_string(details.log_in, "%d-%h-%Y %I:%M:%S%p %Z"));
-    PLOG_VERBOSE << "last log out: still logged in";
+    LOG_VERBOSE("last login: {}", details.summary);
+    LOG_VERBOSE("last log in: {}", to_string(details.log_in, "%d-%h-%Y %I:%M:%S%p %Z"));
+    LOG_VERBOSE("last log out: still logged in");
 
     return details;
 }

--- a/lib/src/platform/linux/load_average.cpp
+++ b/lib/src/platform/linux/load_average.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/iostream_error.h"
+#include "common/include/logging.h"
 #include "lib/include/platform/load_average.h"
 
 #include <cerrno>
@@ -13,7 +14,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 #include <sys/sysinfo.h>
 
@@ -27,10 +27,10 @@ namespace {
 optional<int32_t> GetCpuCount() {
     auto cpu_count = sysconf(_SC_NPROCESSORS_ONLN);
     if (cpu_count == -1) {
-        PLOG_ERROR << "sysconf returned -1 calling get processor count _SC_NPROCESSORS_ONLN";
+        LOG_ERROR("sysconf returned -1 calling get processor count _SC_NPROCESSORS_ONLN");
         return nullopt;
     } else {
-        PLOG_INFO << format(FMT_STRING("sysconf for _SC_NPROCESSORS_ONLN returned {} processors"), cpu_count);
+        LOG_INFO("sysconf for _SC_NPROCESSORS_ONLN returned {} processors", cpu_count);
         return make_optional(cpu_count);
     }
 }
@@ -39,7 +39,7 @@ optional<double> FromString(string str) {
     char *str_end = nullptr;
     auto value = strtod(data(str), &str_end);
     if (data(str) == str_end || errno == ERANGE) {
-        PLOG_ERROR << format(FMT_STRING("error converting string '{}' into a valid double"), str);
+        LOG_ERROR("error converting string '{}' into a valid double", str);
         value = double{0.0};
     }
     return value;
@@ -49,7 +49,7 @@ optional<double> ParseLoadAverage(const string &line) {
     auto parts = vector<string>{};
     boost::split(parts, line, boost::is_any_of(" "), boost::token_compress_on);
     if (parts.size() < 2) {
-        PLOG_ERROR << format(FMT_STRING("unable to parse '{}' into valid load averages"), line);
+        LOG_ERROR("unable to parse '{}' into valid load averages", line);
         return nullopt;
     }
     return FromString(boost::trim_copy(parts.front()));
@@ -61,9 +61,9 @@ optional<double> GetSystemLoadAverage() {
     load_average_file.open(LOAD_AVERAGE_FILENAME, ios_base::in);
 
     if (!load_average_file.is_open() || load_average_file.fail() || load_average_file.bad()) {
-        PLOG_ERROR << format(FMT_STRING("unable to open {} for reading, {}"),
-                             LOAD_AVERAGE_FILENAME,
-                             mmotd::error::ios_flags::to_string(load_average_file));
+        LOG_ERROR("unable to open {} for reading, {}",
+                  LOAD_AVERAGE_FILENAME,
+                  mmotd::error::ios_flags::to_string(load_average_file));
         return nullopt;
     }
     auto load_average_str = string{};

--- a/lib/src/platform/linux/memory.cpp
+++ b/lib/src/platform/linux/memory.cpp
@@ -2,6 +2,7 @@
 #include "common/include/human_size.h"
 #include "common/include/information_definitions.h"
 #include "common/include/information_objects.h"
+#include "common/include/logging.h"
 #include "common/include/posix_error.h"
 #include "lib/include/platform/memory.h"
 
@@ -11,7 +12,6 @@
 #include <tuple>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 #include <sys/sysinfo.h>
 
@@ -25,32 +25,32 @@ optional<mmotd::platform::MemoryDetails> GetMemoryUsage() {
     struct sysinfo info {};
     if (sysinfo(&info) == -1) {
         auto error_str = mmotd::error::posix_error::to_string();
-        PLOG_ERROR << format(FMT_STRING("error calling sysinfo, {}"), error_str);
+        LOG_ERROR("error calling sysinfo, {}", error_str);
         return nullopt;
     }
 
     auto total = uint64_t{info.totalram} * info.mem_unit;
-    PLOG_VERBOSE << format(FMT_STRING("memory total ram: {}, {} bytes"), to_human_size(total), total);
+    LOG_VERBOSE("memory total ram: {}, {} bytes", to_human_size(total), total);
     auto total_high = uint64_t{info.totalhigh} * info.mem_unit;
-    PLOG_VERBOSE << format(FMT_STRING("memory total high ram: {}, {} bytes"), to_human_size(total_high), total_high);
+    LOG_VERBOSE("memory total high ram: {}, {} bytes", to_human_size(total_high), total_high);
     if (total_high != 0) {
         total = (total_high << 32) | total;
     }
 
     auto free = uint64_t{info.freeram} * info.mem_unit;
-    PLOG_VERBOSE << format(FMT_STRING("memory free ram: {}, {} bytes"), to_human_size(free), free);
+    LOG_VERBOSE("memory free ram: {}, {} bytes", to_human_size(free), free);
     auto free_high = uint64_t{info.freehigh} * info.mem_unit;
-    PLOG_VERBOSE << format(FMT_STRING("memory free high ram: {}, {} bytes"), to_human_size(free_high), free_high);
+    LOG_VERBOSE("memory free high ram: {}, {} bytes", to_human_size(free_high), free_high);
     if (free_high != 0) {
         free = (free_high << 32) | free;
     }
 
-    PLOG_VERBOSE << format(FMT_STRING("memory total: {}, {} bytes"), to_human_size(total), total);
-    PLOG_VERBOSE << format(FMT_STRING("memory free: {}, {} bytes"), to_human_size(free), free);
+    LOG_VERBOSE("memory total: {}, {} bytes", to_human_size(total), total);
+    LOG_VERBOSE("memory free: {}, {} bytes", to_human_size(free), free);
     auto percent_used = 0.0;
     if (total != 0) {
         percent_used = (static_cast<double>(total - free) / static_cast<double>(total)) * 100.0;
-        PLOG_VERBOSE << format(FMT_STRING("percent used: {:.01f}"), percent_used);
+        LOG_VERBOSE("percent used: {:.01f}", percent_used);
     }
 
     auto memory_details = mmotd::platform::MemoryDetails{};

--- a/lib/src/platform/linux/network.cpp
+++ b/lib/src/platform/linux/network.cpp
@@ -1,4 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/logging.h"
 #include "common/include/mac_address.h"
 #include "common/include/posix_error.h"
 #include "lib/include/platform/network.h"
@@ -10,7 +11,6 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 #include <scope_guard.hpp>
 
 #include <ifaddrs.h>
@@ -34,9 +34,8 @@ namespace {
 void SetActiveInterfaces(NetworkDevices &devices) {
     int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
     if (sock == -1) {
-        PLOG_ERROR << format(
-            FMT_STRING("opening socket failed, family: AF_PACKET, type: SOCK_DGRAM, protocol: 0, details: {}"),
-            mmotd::error::posix_error::to_string());
+        LOG_ERROR("opening socket failed, family: AF_PACKET, type: SOCK_DGRAM, protocol: 0, details: {}",
+                  mmotd::error::posix_error::to_string());
         return;
     };
     auto socket_closer = sg::make_scope_guard([sock]() noexcept { close(sock); });
@@ -48,15 +47,13 @@ void SetActiveInterfaces(NetworkDevices &devices) {
         memcpy(req.ifr_ifrn.ifrn_name, data(name), min(size(name), static_cast<size_t>(IFNAMSIZ - 1)));
 
         if (ioctl(sock, SIOCGIFFLAGS, &req) == -1) {
-            PLOG_ERROR << format(FMT_STRING("ioctl SIOCGIFFLAGS failed on {}, details: {}"),
-                                 name,
-                                 mmotd::error::posix_error::to_string());
+            LOG_ERROR("ioctl SIOCGIFFLAGS failed on {}, details: {}", name, mmotd::error::posix_error::to_string());
             return;
         }
 
         int flags = req.ifr_ifru.ifru_flags;
         auto active_status = (flags & IFF_UP) != 0;
-        PLOG_VERBOSE << format(FMT_STRING("{} status: {}"), name, active_status ? "active" : "inactive");
+        LOG_VERBOSE("{} status: {}", name, active_status ? "active" : "inactive");
         device.active = active_status;
     }
 }
@@ -68,7 +65,7 @@ namespace mmotd::platform {
 NetworkDevices GetNetworkDevices() {
     struct ifaddrs *addrs = nullptr;
     if (getifaddrs(&addrs) != 0) {
-        PLOG_ERROR << format(FMT_STRING("getifaddrs failed, {}"), mmotd::error::posix_error::to_string());
+        LOG_ERROR("getifaddrs failed, {}", mmotd::error::posix_error::to_string());
         return NetworkDevices{};
     }
     auto freeifaddrs_deleter = sg::make_scope_guard([addrs]() noexcept { freeifaddrs(addrs); });
@@ -86,7 +83,7 @@ NetworkDevices GetNetworkDevices() {
         if (address_family == AF_PACKET) {
             const auto *sock_addr = reinterpret_cast<struct sockaddr_ll *>(ptr->ifa_addr);
             auto mac_address = MacAddress{sock_addr->sll_addr, sock_addr->sll_halen};
-            PLOG_DEBUG << format(FMT_STRING("{} found mac address {}"), interface_name, mac_address.to_string());
+            LOG_DEBUG("{} found mac address {}", interface_name, mac_address.to_string());
             network_devices.AddMacAddress(interface_name, mac_address);
         } else if (address_family == AF_INET || address_family == AF_INET6) {
             auto ip_str = string{};
@@ -103,32 +100,24 @@ NetworkDevices GetNetworkDevices() {
                 }
             }
             const auto family_name = address_family == AF_INET ? string{"ipv4"} : string{"ipv6"};
-            PLOG_DEBUG << format(FMT_STRING("{} found ip {} for family {}"), interface_name, ip_str, family_name);
+            LOG_DEBUG("{} found ip {} for family {}", interface_name, ip_str, family_name);
             auto ip_address = make_address(ip_str);
             if (ip_address.is_unspecified()) {
-                PLOG_DEBUG << format(FMT_STRING("{} with ip address {} is unspecified (empty)"),
-                                     interface_name,
-                                     ip_address.to_string());
+                LOG_DEBUG("{} with ip address {} is unspecified (empty)", interface_name, ip_address.to_string());
                 continue;
             }
             if (ip_address.is_loopback()) {
-                PLOG_DEBUG << format(FMT_STRING("{} with ip address {} is a loopback device"),
-                                     interface_name,
-                                     ip_address.to_string());
+                LOG_DEBUG("{} with ip address {} is a loopback device", interface_name, ip_address.to_string());
                 continue;
             }
             if (ip_address.is_multicast()) {
                 // not a problem that we won't add the ip address
-                PLOG_DEBUG << format(FMT_STRING("{} with ip address {} is a multicast device"),
-                                     interface_name,
-                                     ip_address.to_string());
+                LOG_DEBUG("{} with ip address {} is a multicast device", interface_name, ip_address.to_string());
                 continue;
             }
             if (ip_address.is_v6()) {
                 // Not displaying IPv6 addresses at this point
-                PLOG_DEBUG << format(FMT_STRING("{} with ip address {} is ipv6 [ignoring]"),
-                                     interface_name,
-                                     ip_address.to_string());
+                LOG_DEBUG("{} with ip address {} is ipv6 [ignoring]", interface_name, ip_address.to_string());
                 continue;
             }
             network_devices.AddIpAddress(interface_name, ip_address);

--- a/lib/src/platform/linux/package_management.cpp
+++ b/lib/src/platform/linux/package_management.cpp
@@ -1,4 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/logging.h"
 #include "lib/include/platform/package_management.h"
 
 #include <algorithm>
@@ -9,7 +10,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 namespace fs = std::filesystem;
 using namespace std;
@@ -21,16 +21,16 @@ constexpr static const char *REBOOT_REQUIRED_FILE = "/var/run/reboot-required";
 namespace {
 
 string ReadFile(const char *path_str) {
-    PLOG_VERBOSE << "reading file" << path_str;
+    LOG_VERBOSE("reading file {}", path_str);
     auto path = fs::path(path_str);
     std::error_code ec;
     if (auto file_exists = fs::exists(path, ec); !file_exists || ec) {
-        PLOG_ERROR << format(FMT_STRING("package management file does not exist {}"), path.string());
+        LOG_WARNING("package management file does not exist {}", path.string());
         return string{};
     }
     auto input = ifstream(path);
     if (!input) {
-        PLOG_ERROR << format(FMT_STRING("unable to open package management file {}"), path.string());
+        LOG_ERROR("unable to open package management file {}", path.string());
         return string{};
     }
     auto lines = vector<string>{};
@@ -48,17 +48,16 @@ string ReadFile(const char *path_str) {
 namespace mmotd::platform::package_management {
 
 string GetUpdateDetails() {
-    PLOG_VERBOSE << "[linux] getting package management update details";
+    LOG_VERBOSE("[linux] getting package management update details");
     auto update_details = ReadFile(UPDATES_AVAILABLE_FILE);
-    PLOG_VERBOSE << format(FMT_STRING("[linux] returning from package management update details: {}"), update_details);
+    LOG_VERBOSE("[linux] returning from package management update details: {}", update_details);
     return update_details;
 }
 
 string GetRebootRequired() {
-    PLOG_VERBOSE << "[linux] getting package management reboot required";
+    LOG_VERBOSE("[linux] getting package management reboot required");
     auto reboot_required = ReadFile(REBOOT_REQUIRED_FILE);
-    PLOG_VERBOSE << format(FMT_STRING("[linux] returning from package management reboot required: {}"),
-                           reboot_required);
+    LOG_VERBOSE("[linux] returning from package management reboot required: {}", reboot_required);
     return reboot_required;
 }
 

--- a/lib/src/platform/linux/processes.cpp
+++ b/lib/src/platform/linux/processes.cpp
@@ -1,4 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/logging.h"
 #include "lib/include/platform/processes.h"
 
 #include <algorithm>
@@ -12,7 +13,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 namespace fs = std::filesystem;
 using namespace std;
@@ -28,31 +28,27 @@ vector<string> GetProcessDirectories() {
     //auto flags = fs::directory_options::skip_permission_denied;
     for (auto &dir_entry : fs::directory_iterator(PROC_DIRECTORY, ec /*, flags*/)) {
         if (ec) {
-            PLOG_ERROR << format(FMT_STRING("error encountered while iterating {} directory, {}"),
-                                 PROC_DIRECTORY,
-                                 ec.message());
+            LOG_ERROR("error encountered while iterating {} directory, {}", PROC_DIRECTORY, ec.message());
             return vector<string>{};
         }
 
         auto path_entry = dir_entry.path();
         if (!dir_entry.is_directory()) {
-            //PLOG_DEBUG << format(FMT_STRING("ignoring {} since it is not a directory"), path_entry.string());
+            //LOG_DEBUG("ignoring {} since it is not a directory", path_entry.string());
             continue;
         }
 
         const auto &name = path_entry.stem().string();
         if (!all_of(begin(name), end(name), boost::is_digit())) {
-            //PLOG_DEBUG << format(FMT_STRING("ignoring {} since it is not all digits"), path_entry.string());
+            //LOG_DEBUG("ignoring {} since it is not all digits", path_entry.string());
             continue;
         }
-        //PLOG_DEBUG << format(FMT_STRING("adding process directory {}"), path_entry.string());
+        //LOG_DEBUG("adding process directory {}", path_entry.string());
         process_subdirs.push_back(path_entry.string());
     }
 
     if (ec) {
-        PLOG_ERROR << format(FMT_STRING("error encountered while iterating {} directory, {}"),
-                             PROC_DIRECTORY,
-                             ec.message());
+        LOG_ERROR("error encountered while iterating {} directory, {}", PROC_DIRECTORY, ec.message());
         return vector<string>{};
     }
 

--- a/lib/src/platform/linux/swap.cpp
+++ b/lib/src/platform/linux/swap.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/human_size.h"
+#include "common/include/logging.h"
 #include "common/include/posix_error.h"
 #include "lib/include/platform/swap.h"
 
@@ -9,7 +10,6 @@
 #include <tuple>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 #include <sys/sysinfo.h>
 
@@ -42,7 +42,7 @@ optional<SwapDetails> GetSwapMemoryUsage() {
     struct sysinfo info {};
     if (sysinfo(&info) == -1) {
         auto error_str = mmotd::error::posix_error::to_string();
-        PLOG_ERROR << format(FMT_STRING("error calling sysinfo, {}"), error_str);
+        LOG_ERROR("error calling sysinfo, {}", error_str);
         return nullopt;
     }
 
@@ -55,14 +55,10 @@ optional<SwapDetails> GetSwapMemoryUsage() {
 
     auto swap_details = SwapDetails{total, free, percent_used, false};
 
-    PLOG_VERBOSE << format(FMT_STRING("swap memory total: {}, {} bytes"),
-                           to_human_size(swap_details.total),
-                           swap_details.total);
-    PLOG_VERBOSE << format(FMT_STRING("swap memory free: {}, {} bytes"),
-                           to_human_size(swap_details.free),
-                           swap_details.free);
-    PLOG_VERBOSE << format(FMT_STRING("swap memory percent used: {:.02f}"), swap_details.percent_used);
-    PLOG_VERBOSE << format(FMT_STRING("swap memory encrypted: {}"), swap_details.encrypted);
+    LOG_VERBOSE("swap memory total: {}, {} bytes", to_human_size(swap_details.total), swap_details.total);
+    LOG_VERBOSE("swap memory free: {}, {} bytes", to_human_size(swap_details.free), swap_details.free);
+    LOG_VERBOSE("swap memory percent used: {:.02f}", swap_details.percent_used);
+    LOG_VERBOSE("swap memory encrypted: {}", swap_details.encrypted);
 
     return make_optional(swap_details);
 }

--- a/lib/src/platform/linux/user_accounting_database.cpp
+++ b/lib/src/platform/linux/user_accounting_database.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/chrono_io.h"
+#include "common/include/logging.h"
 #include "common/include/posix_error.h"
 #include "lib/include/platform/user_accounting_database.h"
 
@@ -9,7 +10,6 @@
 
 #include <boost/asio/ip/address.hpp>
 #include <fmt/format.h>
-#include <plog/Log.h>
 #include <scope_guard.hpp>
 
 #include <errno.h>
@@ -42,9 +42,7 @@ DbEntries GetUserAccountEntriesImpl() {
     auto retval = getutent_r(&utmp_buf, &utmp_ptr);
     if (retval != 0 || utmp_ptr == nullptr) {
         auto error_str = retval != 0 ? pe::to_string(retval) : pe::to_string();
-        PLOG_ERROR << format(
-            FMT_STRING("attempting to read first value in user accounting database (utmp) and failed, {}"),
-            error_str);
+        LOG_ERROR("attempting to read first value in user accounting database (utmp) and failed, {}", error_str);
         return DbEntries{};
     }
 
@@ -55,15 +53,12 @@ DbEntries GetUserAccountEntriesImpl() {
     size_t i = 0;
     while (utmp_ptr != nullptr) {
         auto ut_type_str = DbEntry::entry_type_to_string(utmp_ptr->ut_type);
-        PLOG_VERBOSE << format(FMT_STRING("iteration #{}, type: {}, utmpx *: {}"),
-                               ++i,
-                               ut_type_str,
-                               fmt::ptr(utmp_ptr));
+        LOG_VERBOSE("iteration #{}, type: {}, utmpx *: {}", ++i, ut_type_str, fmt::ptr(utmp_ptr));
 
         auto entry = DbEntry::from_utmp(*utmp_ptr);
         if (!entry.empty()) {
             user_account_entries.push_back(entry);
-            PLOG_VERBOSE << format(FMT_STRING("adding user account entry #{}"), user_account_entries.size());
+            LOG_VERBOSE("adding user account entry #{}", user_account_entries.size());
         }
 
         // read the next entry from the database
@@ -74,16 +69,15 @@ DbEntries GetUserAccountEntriesImpl() {
             auto error_value = errno;
             auto error_str = pe::to_string(error_value);
             if (error_value == ENOENT) {
-                PLOG_VERBOSE << format(FMT_STRING("found the end of user accounting database (utmp), {}"), error_str);
+                LOG_VERBOSE("found the end of user accounting database (utmp), {}", error_str);
             } else {
-                PLOG_ERROR << format(
-                    FMT_STRING("attempting to read next value in user accounting database (utmp) and failed, {}"),
-                    error_str);
+                LOG_WARNING("attempting to read next value in user accounting database (utmp) and failed, {}",
+                            error_str);
             }
             utmp_ptr = nullptr;
         }
     }
-    PLOG_VERBOSE << format(FMT_STRING("returning {} user account entries"), user_account_entries.size());
+    LOG_VERBOSE("returning {} user account entries", user_account_entries.size());
     return user_account_entries;
 }
 
@@ -99,12 +93,11 @@ UserInformation GetUserInformationImpl() {
     auto user_id = geteuid();
     auto retval = getpwuid_r(user_id, &pwd, buf.data(), buf.size(), &pwd_ptr);
     if (pwd_ptr == nullptr && retval == 0) {
-        PLOG_ERROR << format(FMT_STRING("getpwnam_r for user id {} did not return a pwd structure or an error code"),
-                             user_id);
+        LOG_ERROR("getpwnam_r for user id {} did not return a pwd structure or an error code", user_id);
         return UserInformation{};
     } else if (pwd_ptr == nullptr && retval != 0) {
         auto error_str = pe::to_string(retval);
-        PLOG_ERROR << format(FMT_STRING("getpwnam_r for user id {} failed, {}"), user_id, error_str);
+        LOG_ERROR("getpwnam_r for user id {} failed, {}", user_id, error_str);
         return UserInformation{};
     }
     return UserInformation::from_passwd(pwd);
@@ -143,7 +136,7 @@ DbEntry DbEntry::from_utmp(const utmp &db) {
         ip = ip_address{};
     }
     auto entry = DbEntry{static_cast<ENTRY_TYPE>(db.ut_type), device_name, username, hostname, db.ut_tv.tv_sec, ip};
-    PLOG_VERBOSE << format(FMT_STRING("parsed entry: {}"), entry.to_string());
+    LOG_VERBOSE("parsed entry: {}", entry.to_string());
     return entry;
 }
 

--- a/lib/src/platform/windows/boot_time.cpp
+++ b/lib/src/platform/windows/boot_time.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/chrono_io.h"
+#include "common/include/logging.h"
 #include "common/include/posix_error.h"
 
 #include <chrono>
@@ -11,7 +12,6 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using namespace std;
@@ -28,7 +28,7 @@ optional<string> GetBootTime() {
     //    if (auto errno_str = mmotd::error::posix_error::to_string(); !errno_str.empty()) {
     //        error_str += format(FMT_STRING(", details: {}"), errno_str);
     //    }
-    //    PLOG_ERROR << error_str;
+    //    LOG_ERROR << error_str;
     //    return nullopt;
     //}
     //auto boot_time_point = std::chrono::system_clock::from_time_t(result.tv_sec);

--- a/lib/src/platform/windows/package_management.cpp
+++ b/lib/src/platform/windows/package_management.cpp
@@ -1,21 +1,20 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/logging.h"
 #include "lib/include/platform/package_management.h"
 
 #include <string>
-
-#include <plog/Log.h>
 
 using namespace std;
 
 namespace mmotd::platform::package_management {
 
 string GetUpdateDetails() {
-    PLOG_VERBOSE << "[windows] getting package management update details";
+    LOG_VERBOSE("[windows] getting package management update details");
     return string{};
 }
 
 string GetRebootRequired() {
-    PLOG_VERBOSE << "[windows] getting package management reboot required";
+    LOG_VERBOSE("[windows] getting package management reboot required");
     return string{};
 }
 

--- a/lib/src/system_details.cpp
+++ b/lib/src/system_details.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/assertion/include/assertion.h"
+#include "common/include/logging.h"
 #include "common/include/posix_error.h"
 #include "lib/include/system_details.h"
 
@@ -9,7 +10,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using namespace fmt;
 using namespace std;

--- a/lib/src/users_logged_in.cpp
+++ b/lib/src/users_logged_in.cpp
@@ -1,4 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/logging.h"
 #include "lib/include/computer_information.h"
 #include "lib/include/platform/user_accounting_database.h"
 #include "lib/include/users_logged_in.h"
@@ -7,7 +8,6 @@
 #include <iterator>
 
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using namespace mmotd::platform;
 using fmt::format;
@@ -38,9 +38,9 @@ string UsersLoggedIn::GetUsersLoggedIn() {
     auto user_information = GetUserInformation();
     auto user_account_enteries = GetDbEntries<ENTRY_TYPE::User>();
     if (user_information.empty() || user_account_enteries.empty()) {
-        PLOG_ERROR << format(FMT_STRING("user information empty: {}, user account entry size: {}"),
-                             user_information.empty(),
-                             user_account_enteries.size());
+        LOG_ERROR("user information empty: {}, user account entry size: {}",
+                  user_information.empty(),
+                  user_account_enteries.size());
         // should never happen
         return string{};
     }
@@ -60,9 +60,7 @@ string UsersLoggedIn::GetUsersLoggedIn() {
                                });
 
     if (user_count == 0 || user_account_entry_ptr == nullptr) {
-        PLOG_ERROR << format(FMT_STRING("user count: {}, user account ptr: {}"),
-                             user_count,
-                             fmt::ptr(user_account_entry_ptr));
+        LOG_ERROR("user count: {}, user account ptr: {}", user_count, fmt::ptr(user_account_entry_ptr));
         // should never happen
         return string{};
     }

--- a/lib/src/weather_info.cpp
+++ b/lib/src/weather_info.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/chrono_io.h"
+#include "common/include/logging.h"
 #include "lib/include/computer_information.h"
 #include "lib/include/http_request.h"
 #include "lib/include/weather_info.h"
@@ -10,7 +11,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <fmt/format.h>
-#include <plog/Log.h>
 
 using fmt::format;
 using namespace std;
@@ -92,32 +92,29 @@ tuple<string, string, string, string> WeatherInfo::GetWeatherInfo() {
         location_str = boost::trim_copy(weather_str.substr(0, i));
         weather_str = boost::trim_copy(weather_str.substr(i + 1));
     } else {
-        PLOG_ERROR << "weather response appears to be malformed";
+        LOG_ERROR("weather response appears to be malformed");
         return make_tuple(location_str, weather_str, string{}, string{});
     }
 
     const auto sunrise_sunset_regex = regex(R"((\d{2}:\d{2}:\d{2}) (\d{2}:\d{2}:\d{2}))", std::regex::ECMAScript);
     auto match = smatch{};
     if (!regex_search(weather_str, match, sunrise_sunset_regex)) {
-        PLOG_ERROR << "weather information does not seem to include sunrise and sunset";
+        LOG_ERROR("weather information does not seem to include sunrise and sunset");
         return make_tuple(location_str, weather_str, string{}, string{});
     }
 
     auto weather = trim_copy(weather_str.substr(0, match.position(0)));
-    PLOG_INFO << format(FMT_STRING("weather: '{}'"), weather);
+    LOG_INFO("weather: '{}'", weather);
     auto sunrise_str = weather_str.substr(match.position(1), match.length(1));
-    PLOG_INFO << format(FMT_STRING("sunrise: '{}'"), sunrise_str);
+    LOG_INFO("sunrise: '{}'", sunrise_str);
     auto sunset_str = weather_str.substr(match.position(2), match.length(2));
-    PLOG_INFO << format(FMT_STRING("sunset: '{}'"), sunset_str);
+    LOG_INFO("sunset: '{}'", sunset_str);
 
     auto [sunrise_parsed, sunset_parsed] = ParseSunriseSunset(sunrise_str, sunset_str);
     sunrise_parsed = empty(sunrise_parsed) ? sunrise_str : sunrise_parsed;
     sunset_parsed = empty(sunset_parsed) ? sunset_str : sunset_parsed;
 
-    PLOG_INFO << format(FMT_STRING("weather: '{}, Sunrise (parsed): {}, Sunset (parsed): {}'"),
-                        weather,
-                        sunrise_parsed,
-                        sunset_parsed);
+    LOG_INFO("weather: '{}, Sunrise (parsed): {}, Sunset (parsed): {}'", weather, sunrise_parsed, sunset_parsed);
     return make_tuple(location_str, weather, sunrise_parsed, sunset_parsed);
 }
 

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -1,9 +1,12 @@
 #define CATCH_CONFIG_RUNNER
 #include "common/include/logging.h"
 
+#include <clocale>
+
 #include <catch2/catch.hpp>
 
 int main(int argc, char *argv[]) {
-    mmotd::logging::DefaultInitializeLogging("mmotd_test.log");
+    setlocale(LC_ALL, "en_US.UTF-8");
+    mmotd::logging::InitializeLogging(argv[0]);
     return Catch::Session().run(argc, argv);
 }


### PR DESCRIPTION
Remove: plog from the project so there is one less dependency.
Add: thin wrapper around `fmt::print` to a file and `stderr` for simple
logging capabilities of a short-lived app.

Closes #51.