### PR TITLE
Running static analysis and valgrind on mmotd

### DIFF
--- a/apps/mmotd/src/main.cpp
+++ b/apps/mmotd/src/main.cpp
@@ -1,6 +1,7 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "apps/mmotd/include/cli_app_options_creator.h"
 #include "apps/mmotd/include/main.h"
+#include "common/include/algorithm.h"
 #include "common/include/app_options.h"
 #include "common/include/logging.h"
 #include "common/results/include/output_template.h"
@@ -11,9 +12,11 @@
 #include <cstdlib>
 #include <iostream>
 
+#include <backward.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <fmt/format.h>
 
+using mmotd::algorithms::unused;
 using namespace fmt;
 using namespace std;
 
@@ -45,6 +48,8 @@ void PrintMmotd(const AppOptions &app_options) {
 
 int main_impl(int argc, char **argv) {
     setlocale(LC_ALL, "en_US.UTF-8");
+    auto signal_handling = backward::SignalHandling{};
+    unused(signal_handling);
 
     mmotd::logging::InitializeLogging(argv[0]);
 

--- a/apps/mmotd_raw/src/main.cpp
+++ b/apps/mmotd_raw/src/main.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <regex>
 
+#include <backward.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/exception_ptr.hpp>
@@ -17,6 +18,7 @@
 #include <fmt/color.h>
 #include <fmt/format.h>
 
+using mmotd::algorithms::unused;
 using namespace fmt;
 using namespace std;
 
@@ -49,7 +51,6 @@ void PrintMmotdRaw() {
     auto &computer_information = mmotd::information::ComputerInformation::Instance();
     const auto &informations = computer_information.GetAllInformation();
     const auto width = GetColumnWidth(informations);
-    mmotd::algorithms::unused(width);
     for (const auto &information : informations) {
         auto name = GetInformationNameString(information);
         auto value = GetInformationValueString(information);
@@ -67,8 +68,10 @@ void PrintMmotdRaw() {
 
 int main_impl(int argc, char **argv) {
     setlocale(LC_ALL, "en_US.UTF-8");
+    auto signal_handling = backward::SignalHandling{};
+    unused(signal_handling);
 
-    mmotd::algorithms::unused(argc, argv);
+    unused(argc);
     mmotd::logging::InitializeLogging(argv[0]);
 
     PrintMmotdRaw();

--- a/cmake/find_dependencies.cmake
+++ b/cmake/find_dependencies.cmake
@@ -45,8 +45,8 @@ unset(MESSAGE_QUIET)
 # Component: Backward.  Stack trace library
 FetchContent_Declare(Backward
     GIT_REPOSITORY   https://github.com/bombela/backward-cpp.git
-    GIT_TAG          v1.5
-    GIT_PROGRESS     TRUE
+    #GIT_TAG          v1.5
+    #GIT_PROGRESS     TRUE
 )
 set(MESSAGE_QUIET ON)
 FetchContent_MakeAvailable(Backward)

--- a/common/assertion/src/assertion.cpp
+++ b/common/assertion/src/assertion.cpp
@@ -30,16 +30,17 @@ inline constexpr string_view GetExceptionType(const char *exception_type) noexce
 }
 
 inline string GetSourceLocation(string file_name, string function_name, long line) {
-    auto source_location = empty(file_name) ? string{} : string(data(file_name));
+    auto source_location = string{};
+    if (!empty(file_name)) {
+        source_location = file_name;
+    }
     if (!empty(function_name)) {
-        source_location +=
-            empty(source_location) ? string(data(function_name)) : format(FMT_STRING(":{}"), function_name);
+        source_location += format(FMT_STRING("{}{}"), (empty(source_location) ? "" : ":"), function_name);
     }
-    if (empty(source_location) && line == 0) {
-        return string{};
-    } else {
-        return format(FMT_STRING("{}@{}"), source_location, line);
+    if (line != 0) {
+        source_location = format(FMT_STRING("{}@{}"), source_location, line);
     }
+    return source_location;
 }
 
 inline string GetExceptionAndMessage(const char *exception_type_str, const char *msg_str) {

--- a/common/include/information_defs.h
+++ b/common/include/information_defs.h
@@ -1,4 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/information_decls.h"
 CATEGORY_INFO_DEF(GENERAL, general, 110)
 CATEGORY_INFO_DEF(NETWORK_INFO, network info, 111)
 CATEGORY_INFO_DEF(BOOT_TIME, boot time, 112)

--- a/common/include/information_objects.h
+++ b/common/include/information_objects.h
@@ -1,6 +1,7 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
 #include "common/include/big_five_macros.h"
+#include "common/include/informations.h"
 
 #include <iterator>
 #include <vector>

--- a/common/include/informations.h
+++ b/common/include/informations.h
@@ -1,6 +1,7 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
 #include "common/include/big_five_macros.h"
+#include "common/include/information.h"
 
 #include <cstddef>
 #include <initializer_list>

--- a/common/src/source_location_common.cpp
+++ b/common/src/source_location_common.cpp
@@ -53,6 +53,8 @@ string TrimFileName(const char *file) noexcept {
 // static optional<std::__1::string> mmotd::results::TemplateString::GetInformationValue(...)
 // static optional<mmotd::information::Information> mmotd::results::TemplateString::FindInformation(...)
 // static optional<std::__1::string> mmotd::results::TemplateString::GetInformationValue(...)
+// 'std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >' => 'string'
+// boost::iterator_range<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > boost::algorithm::detail::first_finderF<char const*, boost::algorithm::is_iequal>::operator()<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >(__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, __gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >) const (finder.hpp:76)
 
 string
 TrimFunction(const char *function, FunctionArgStrategy arg_strategy, FunctionReturnStrategy return_strategy) noexcept {

--- a/lib/src/platform/linux/user_accounting_database.cpp
+++ b/lib/src/platform/linux/user_accounting_database.cpp
@@ -128,10 +128,10 @@ DbEntry DbEntry::from_utmp(const utmp &db) {
     auto username = strlen(db.ut_user) > 0 ? string{db.ut_user} : string{};
     auto hostname = strlen(db.ut_host) > 0 ? string{db.ut_host} : string{};
 
-    auto buffer = vector<char>{sizeof(int32_t) * 4, 0};
-    memcpy(buffer.data(), db.ut_addr_v6, buffer.size());
+    auto buffer = vector<char>(sizeof(db.ut_addr_v6), 0);
+    memcpy(data(buffer), db.ut_addr_v6, size(buffer));
     auto ec = boost::system::error_code{};
-    auto ip = make_address(buffer.data(), ec);
+    auto ip = make_address(data(buffer), ec);
     if (ec) {
         ip = ip_address{};
     }

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -1,12 +1,18 @@
 #define CATCH_CONFIG_RUNNER
+#include "common/include/algorithm.h"
 #include "common/include/logging.h"
 
 #include <clocale>
 
+#include <backward.hpp>
 #include <catch2/catch.hpp>
+
+using mmotd::algorithms::unused;
 
 int main(int argc, char *argv[]) {
     setlocale(LC_ALL, "en_US.UTF-8");
+    auto signal_handling = backward::SignalHandling{};
+    unused(signal_handling);
     mmotd::logging::InitializeLogging(argv[0]);
     return Catch::Session().run(argc, argv);
 }


### PR DESCRIPTION
Running clang's scan-build with almost all of the checkers enabled.
Also running valgrind within Linux on all the binaries built within the
project.  I was able to find quite a few subtle bugs.  One I tracked
down to the backward external library.  By the time I identified what
was happening, I looked at the master branch of backward and found the
author had already fixed the problem months ago but there was no new
release.  This makes one more external dependency which I'm relying on
`HEAD` instead of a stable release.