### PR TITLE
Adjust api on thread entry info to return void

### DIFF
--- a/common/assertion/src/exception.cpp
+++ b/common/assertion/src/exception.cpp
@@ -22,8 +22,7 @@ InvalidArgument::InvalidArgument(const std::string &message, bool includes_stack
     LOG_ERROR("{}", what());
 }
 
-InvalidArgument::~InvalidArgument() noexcept {
-}
+InvalidArgument::~InvalidArgument() noexcept = default;
 
 DomainError::DomainError(const char *message, bool includes_stack_trace) :
     boost::exception(),
@@ -37,8 +36,7 @@ DomainError::DomainError(const std::string &message, bool includes_stack_trace) 
     LOG_ERROR("{}", what());
 }
 
-DomainError::~DomainError() noexcept {
-}
+DomainError::~DomainError() noexcept = default;
 
 LengthError::LengthError(const char *message, bool includes_stack_trace) :
     boost::exception(),
@@ -52,8 +50,7 @@ LengthError::LengthError(const std::string &message, bool includes_stack_trace) 
     LOG_ERROR("{}", what());
 }
 
-LengthError::~LengthError() noexcept {
-}
+LengthError::~LengthError() noexcept = default;
 
 OutOfRange::OutOfRange(const char *message, bool includes_stack_trace) :
     boost::exception(),
@@ -67,8 +64,7 @@ OutOfRange::OutOfRange(const std::string &message, bool includes_stack_trace) :
     LOG_ERROR("{}", what());
 }
 
-OutOfRange::~OutOfRange() noexcept {
-}
+OutOfRange::~OutOfRange() noexcept = default;
 
 RuntimeError::RuntimeError(const char *message, bool includes_stack_trace) :
     boost::exception(),
@@ -82,8 +78,7 @@ RuntimeError::RuntimeError(const std::string &message, bool includes_stack_trace
     LOG_ERROR("{}", what());
 }
 
-RuntimeError::~RuntimeError() noexcept {
-}
+RuntimeError::~RuntimeError() noexcept = default;
 
 RangeError::RangeError(const char *message, bool includes_stack_trace) :
     boost::exception(), std::range_error(includes_stack_trace ? message : MakeExceptionMessage("RangeError", message)) {
@@ -96,8 +91,7 @@ RangeError::RangeError(const std::string &message, bool includes_stack_trace) :
     LOG_ERROR("{}", what());
 }
 
-RangeError::~RangeError() noexcept {
-}
+RangeError::~RangeError() noexcept = default;
 
 OverflowError::OverflowError(const char *message, bool includes_stack_trace) :
     boost::exception(),
@@ -111,8 +105,7 @@ OverflowError::OverflowError(const std::string &message, bool includes_stack_tra
     LOG_ERROR("{}", what());
 }
 
-OverflowError::~OverflowError() noexcept {
-}
+OverflowError::~OverflowError() noexcept = default;
 
 UnderflowError::UnderflowError(const char *message, bool includes_stack_trace) :
     boost::exception(),
@@ -126,7 +119,6 @@ UnderflowError::UnderflowError(const std::string &message, bool includes_stack_t
     LOG_ERROR("{}", what());
 }
 
-UnderflowError::~UnderflowError() noexcept {
-}
+UnderflowError::~UnderflowError() noexcept = default;
 
 } // namespace mmotd::assertion

--- a/lib/include/boot_time.h
+++ b/lib/include/boot_time.h
@@ -16,7 +16,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(BootTime);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 };
 
 } // namespace mmotd::information

--- a/lib/include/external_network.h
+++ b/lib/include/external_network.h
@@ -15,10 +15,10 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(ExternalNetwork);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 
 private:
-    bool ParseJsonResponse(const std::string &response);
+    void ParseJsonResponse(const std::string &response);
 };
 
 } // namespace mmotd::information

--- a/lib/include/file_system.h
+++ b/lib/include/file_system.h
@@ -16,7 +16,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(FileSystem);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 };
 
 } // namespace mmotd::information

--- a/lib/include/fortune.h
+++ b/lib/include/fortune.h
@@ -15,7 +15,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(Fortune);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 };
 
 } // namespace mmotd::information

--- a/lib/include/general.h
+++ b/lib/include/general.h
@@ -15,7 +15,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(General);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 };
 
 } // namespace mmotd::information

--- a/lib/include/information_provider.h
+++ b/lib/include/information_provider.h
@@ -24,10 +24,10 @@ public:
 
     const std::vector<Information> &GetInformations() const;
 
-    bool LookupInformation();
+    void LookupInformation();
 
 protected:
-    virtual bool FindInformation() = 0;
+    virtual void FindInformation() = 0;
 
     void AddInformation(Information information);
 

--- a/lib/include/lastlog.h
+++ b/lib/include/lastlog.h
@@ -16,7 +16,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(LastLog);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 };
 
 } // namespace mmotd::information

--- a/lib/include/load_average.h
+++ b/lib/include/load_average.h
@@ -15,7 +15,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(LoadAverage);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 };
 
 } // namespace mmotd::information

--- a/lib/include/memory.h
+++ b/lib/include/memory.h
@@ -14,7 +14,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(Memory);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 };
 
 } // namespace mmotd::information

--- a/lib/include/network.h
+++ b/lib/include/network.h
@@ -14,7 +14,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(NetworkInfo);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 };
 
 } // namespace mmotd::information

--- a/lib/include/package_management.h
+++ b/lib/include/package_management.h
@@ -14,7 +14,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(PackageManagement);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 };
 
 } // namespace mmotd::information

--- a/lib/include/processes.h
+++ b/lib/include/processes.h
@@ -14,7 +14,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(Processes);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 };
 
 } // namespace mmotd::information

--- a/lib/include/swap.h
+++ b/lib/include/swap.h
@@ -14,7 +14,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(Swap);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 };
 
 } // namespace mmotd::information

--- a/lib/include/system_information.h
+++ b/lib/include/system_information.h
@@ -21,7 +21,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(SystemInformation);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 
 private:
     void CreateInformationObjects(const mmotd::platform::SystemDetails &details);

--- a/lib/include/users_logged_in.h
+++ b/lib/include/users_logged_in.h
@@ -15,7 +15,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(UsersLoggedIn);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 
     using Detail = std::tuple<std::string, std::string>;
     using Details = std::vector<Detail>;

--- a/lib/include/weather_info.h
+++ b/lib/include/weather_info.h
@@ -14,7 +14,7 @@ public:
     DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_VIRTUAL_DESTRUCTOR(WeatherInfo);
 
 protected:
-    bool FindInformation() override;
+    void FindInformation() override;
 
 private:
     std::tuple<std::string, std::string, std::string, std::string> GetWeatherInfo();

--- a/lib/src/boot_time.cpp
+++ b/lib/src/boot_time.cpp
@@ -28,15 +28,13 @@ namespace mmotd::information {
 static const bool boot_time_factory_registered =
     RegisterInformationProvider([]() { return make_unique<mmotd::information::BootTime>(); });
 
-bool BootTime::FindInformation() {
+void BootTime::FindInformation() {
     auto boot_time_holder = mmotd::platform::GetBootTime();
     auto boot_time = boot_time_holder ? *boot_time_holder : std::chrono::system_clock::now();
 
     auto info = GetInfoTemplate(InformationId::ID_BOOT_TIME_BOOT_TIME);
     info.SetValue(chrono::io::to_string(boot_time, "%a, %d-%h-%Y %I:%M%p %Z"));
     AddInformation(info);
-
-    return true;
 }
 
 } // namespace mmotd::information

--- a/lib/src/file_system.cpp
+++ b/lib/src/file_system.cpp
@@ -19,12 +19,12 @@ namespace mmotd::information {
 static const bool file_system_factory_registered =
     RegisterInformationProvider([]() { return make_unique<mmotd::information::FileSystem>(); });
 
-bool FileSystem::FindInformation() {
+void FileSystem::FindInformation() {
     auto ec = error_code{};
     auto root_fs = std::filesystem::space("/", ec);
     if (ec) {
         LOG_ERROR("getting fs::space on root file system, details: {}", ec.message());
-        return false;
+        return;
     }
 
     auto usage = GetInfoTemplate(InformationId::ID_FILE_SYSTEM_USAGE);
@@ -44,8 +44,6 @@ bool FileSystem::FindInformation() {
     auto available = GetInfoTemplate(InformationId::ID_FILE_SYSTEM_AVAILABLE);
     available.SetValueArgs(root_fs.available);
     AddInformation(available);
-
-    return true;
 }
 
 } // namespace mmotd::information

--- a/lib/src/fortune.cpp
+++ b/lib/src/fortune.cpp
@@ -87,16 +87,16 @@ struct StrFileHeader {
     string flags_to_string() const {
         auto flags_str = vector<string>{};
         if (flags == Flags::None) {
-            flags_str.push_back("none");
+            flags_str.emplace_back("none");
         }
         if ((flags & Flags::Random) != Flags::None) {
-            flags_str.push_back("random");
+            flags_str.emplace_back("random");
         }
         if ((flags & Flags::Ordered) != Flags::None) {
-            flags_str.push_back("ordered");
+            flags_str.emplace_back("ordered");
         }
         if ((flags & Flags::Rotated) != Flags::None) {
-            flags_str.push_back("rotated");
+            flags_str.emplace_back("rotated");
         }
         return format(FMT_STRING("[{}]"), boost::join(flags_str, ", "));
     }
@@ -351,14 +351,12 @@ optional<string> GetRandomFortune(const string &fortune_name) {
 
 namespace mmotd::information {
 
-bool Fortune::FindInformation() {
+void Fortune::FindInformation() {
     if (auto fortune_holder = GetRandomFortune("softwareengineering"); fortune_holder) {
         auto fortune = GetInfoTemplate(InformationId::ID_FORTUNE_FORTUNE);
         fortune.SetValueArgs(*fortune_holder);
         AddInformation(fortune);
-        return true;
     }
-    return false;
 }
 
 } // namespace mmotd::information

--- a/lib/src/general.cpp
+++ b/lib/src/general.cpp
@@ -121,10 +121,10 @@ string Greetings::GetLocalDateTime() const {
 
 namespace mmotd::information {
 
-bool General::FindInformation() {
+void General::FindInformation() {
     auto user_info = mmotd::platform::user::GetUserInformation();
     if (user_info.empty()) {
-        return false;
+        return;
     }
 
     auto username = GetInfoTemplate(InformationId::ID_GENERAL_USER_NAME);
@@ -142,8 +142,6 @@ bool General::FindInformation() {
     auto emoji_info = GetInfoTemplate(InformationId::ID_GENERAL_LOCAL_TIME_EMOJI);
     emoji_info.SetValue(Greetings{}.GetTimeOfDayEmoji());
     AddInformation(emoji_info);
-
-    return true;
 }
 
 } // namespace mmotd::information

--- a/lib/src/http_request.cpp
+++ b/lib/src/http_request.cpp
@@ -2,6 +2,8 @@
 #include "common/include/logging.h"
 #include "lib/include/http_request.h"
 
+#include <utility>
+
 #include <boost/asio/connect.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl/stream.hpp>
@@ -31,7 +33,7 @@ namespace {
 class HttpClient {
 public:
     HttpClient() = default;
-    explicit HttpClient(HttpProtocol protocol, const string &host, const string &port, const string &path);
+    explicit HttpClient(HttpProtocol protocol, string host, string port, string path);
 
     optional<string> MakeRequest();
 
@@ -62,8 +64,8 @@ private:
     string path_;
 };
 
-HttpClient::HttpClient(HttpProtocol protocol, const string &host, const string &port, const string &path) :
-    protocol_(protocol), host_(host), port_(port), path_(path) {
+HttpClient::HttpClient(HttpProtocol protocol, string host, string port, string path) :
+    protocol_(protocol), host_(std::move(host)), port_(std::move(port)), path_(std::move(path)) {
 }
 
 tcp::resolver::results_type HttpClient::Resolve(asio::io_context &ctx) {
@@ -182,7 +184,9 @@ optional<string> HttpClient::MakeRequest() {
 namespace mmotd::networking {
 
 HttpRequest::HttpRequest(HttpProtocol protocol, string host, string port) :
-    protocol_(protocol), host_(host), port_(port.empty() ? (protocol_ == HttpProtocol::HTTPS ? "443" : "80") : port) {
+    protocol_(protocol),
+    host_(std::move(host)),
+    port_(port.empty() ? (protocol_ == HttpProtocol::HTTPS ? "443" : "80") : port) {
 }
 
 optional<string> HttpRequest::MakeRequest(string path) {

--- a/lib/src/information_provider.cpp
+++ b/lib/src/information_provider.cpp
@@ -17,19 +17,17 @@ using namespace std;
 
 namespace mmotd::information {
 
-InformationProvider::InformationProvider() {
-}
+InformationProvider::InformationProvider() = default;
 
-InformationProvider::~InformationProvider() {
-}
+InformationProvider::~InformationProvider() = default;
 
 const std::vector<Information> &InformationProvider::GetInformations() const {
     return informations_;
 }
 
-bool InformationProvider::LookupInformation() {
+void InformationProvider::LookupInformation() {
     try {
-        return FindInformation();
+        FindInformation();
     } catch (boost::exception &ex) {
         auto diag = boost::diagnostic_information(ex);
         LOG_ERROR("caught boost::exception in LookupInformation: {}", diag);
@@ -37,7 +35,6 @@ bool InformationProvider::LookupInformation() {
         auto diag = boost::diagnostic_information(ex);
         LOG_ERROR("caught std::exception in LookupInformation: {}", empty(diag) ? ex.what() : data(diag));
     }
-    return false;
 }
 
 void InformationProvider::AddInformation(Information information) {

--- a/lib/src/lastlog.cpp
+++ b/lib/src/lastlog.cpp
@@ -16,7 +16,7 @@ namespace mmotd::information {
 static const bool last_log_information_factory_registered =
     RegisterInformationProvider([]() { return make_unique<mmotd::information::LastLog>(); });
 
-bool LastLog::FindInformation() {
+void LastLog::FindInformation() {
     auto lastlog_details = mmotd::platform::GetLastLogDetails();
 
     auto last_log = GetInfoTemplate(InformationId::ID_LAST_LOGIN_LOGIN_SUMMARY);
@@ -34,8 +34,6 @@ bool LastLog::FindInformation() {
         log_out.SetValue(chrono::io::to_string(lastlog_details.log_out, "%a, %d-%h-%Y %I:%M%p %Z"));
     }
     AddInformation(log_out);
-
-    return true;
 }
 
 } // namespace mmotd::information

--- a/lib/src/load_average.cpp
+++ b/lib/src/load_average.cpp
@@ -12,7 +12,7 @@ namespace mmotd::information {
 static const bool load_average_information_factory_registered =
     RegisterInformationProvider([]() { return make_unique<mmotd::information::LoadAverage>(); });
 
-bool LoadAverage::FindInformation() {
+void LoadAverage::FindInformation() {
     auto details = mmotd::platform::GetLoadAverageDetails();
     auto [processor_cnt, ld_average] = details;
 
@@ -23,8 +23,6 @@ bool LoadAverage::FindInformation() {
     auto load_average = GetInfoTemplate(InformationId::ID_LOAD_AVERAGE_LOAD_AVERAGE);
     load_average.SetValueArgs(ld_average);
     AddInformation(load_average);
-
-    return true;
 }
 
 } // namespace mmotd::information

--- a/lib/src/memory.cpp
+++ b/lib/src/memory.cpp
@@ -20,7 +20,7 @@ namespace mmotd::information {
 static const bool memory_information_factory_registered =
     RegisterInformationProvider([]() { return make_unique<mmotd::information::Memory>(); });
 
-bool Memory::FindInformation() {
+void Memory::FindInformation() {
     auto details = mmotd::platform::GetMemoryDetails();
 
     auto total = GetInfoTemplate(InformationId::ID_MEMORY_USAGE_TOTAL);
@@ -34,8 +34,6 @@ bool Memory::FindInformation() {
     auto percent_used = GetInfoTemplate(InformationId::ID_MEMORY_USAGE_PERCENT_USED);
     percent_used.SetValueArgs(details.percent_used, to_human_size(details.total));
     AddInformation(percent_used);
-
-    return true;
 }
 
 } // namespace mmotd::information

--- a/lib/src/network.cpp
+++ b/lib/src/network.cpp
@@ -19,7 +19,7 @@ namespace mmotd::information {
 static const bool network_information_factory_registered =
     RegisterInformationProvider([]() { return make_unique<mmotd::information::NetworkInfo>(); });
 
-bool NetworkInfo::FindInformation() {
+void NetworkInfo::FindInformation() {
     auto network_devices = mmotd::platform::GetNetworkDevices();
     for (const auto &network_device : network_devices) {
         auto interface_name_info = GetInfoTemplate(InformationId::ID_NETWORK_INFO_INTERFACE_NAME);
@@ -36,7 +36,6 @@ bool NetworkInfo::FindInformation() {
             AddInformation(ip_info);
         }
     }
-    return true;
 }
 
 } // namespace mmotd::information

--- a/lib/src/package_management.cpp
+++ b/lib/src/package_management.cpp
@@ -19,7 +19,7 @@ namespace mmotd::information {
 static const bool package_management_information_factory_registered =
     RegisterInformationProvider([]() { return make_unique<mmotd::information::PackageManagement>(); });
 
-bool PackageManagement::FindInformation() {
+void PackageManagement::FindInformation() {
     auto update_details = platform::package_management::GetUpdateDetails();
     if (!empty(update_details)) {
         auto update_details_info = GetInfoTemplate(InformationId::ID_PACKAGE_MANAGEMENT_UPDATE_DETAILS);
@@ -34,7 +34,6 @@ bool PackageManagement::FindInformation() {
         LOG_VERBOSE("set the value of package management reboot required: {}", reboot_required);
         AddInformation(reboot_required_info);
     }
-    return true;
 }
 
 } // namespace mmotd::information

--- a/lib/src/platform/linux/system_information.cpp
+++ b/lib/src/platform/linux/system_information.cpp
@@ -133,7 +133,7 @@ optional<tuple<int, int, int>> ParseOsVersion(const string &version_str) {
         LOG_ERROR("unable to split '{}' into a version string", version_str);
         return nullopt;
     }
-    int major, minor, patch = 0;
+    int major = 0, minor = 0, patch = 0;
     auto major_holder = ParseIndividualOsVersion(version_numbers[0]);
     if (major_holder) {
         major = *major_holder;

--- a/lib/src/platform/linux/user_accounting_database.cpp
+++ b/lib/src/platform/linux/user_accounting_database.cpp
@@ -4,6 +4,9 @@
 #include "common/include/posix_error.h"
 #include "lib/include/platform/user_accounting_database.h"
 
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -12,10 +15,7 @@
 #include <fmt/format.h>
 #include <scope_guard.hpp>
 
-#include <errno.h>
 #include <pwd.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
 #include <utmpx.h>
 

--- a/lib/src/processes.cpp
+++ b/lib/src/processes.cpp
@@ -18,15 +18,13 @@ namespace mmotd::information {
 static const bool processes_information_factory_registered =
     RegisterInformationProvider([]() { return make_unique<mmotd::information::Processes>(); });
 
-bool Processes::FindInformation() {
+void Processes::FindInformation() {
     auto processes_count_holder = mmotd::platform::GetProcessCount();
     auto processes_count = processes_count_holder ? *processes_count_holder : size_t{0};
 
     auto process_count = GetInfoTemplate(InformationId::ID_PROCESSES_PROCESS_COUNT);
     process_count.SetValueArgs(processes_count);
     AddInformation(process_count);
-
-    return true;
 }
 
 } // namespace mmotd::information

--- a/lib/src/swap.cpp
+++ b/lib/src/swap.cpp
@@ -14,7 +14,7 @@ namespace mmotd::information {
 static const bool swap_usage_factory_registered =
     RegisterInformationProvider([]() { return make_unique<mmotd::information::Swap>(); });
 
-bool Swap::FindInformation() {
+void Swap::FindInformation() {
     auto details = mmotd::platform::GetSwapDetails();
 
     auto total = GetInfoTemplate(InformationId::ID_SWAP_USAGE_TOTAL);
@@ -28,8 +28,6 @@ bool Swap::FindInformation() {
     auto percent_used = GetInfoTemplate(InformationId::ID_SWAP_USAGE_PERCENT_USED);
     percent_used.SetValueArgs(details.percent_used, to_human_size(details.total));
     AddInformation(percent_used);
-
-    return true;
 }
 
 } // namespace mmotd::information

--- a/lib/src/system_information.cpp
+++ b/lib/src/system_information.cpp
@@ -16,13 +16,11 @@ namespace mmotd::information {
 static const bool system_information_factory_registered =
     RegisterInformationProvider([]() { return make_unique<mmotd::information::SystemInformation>(); });
 
-bool SystemInformation::FindInformation() {
+void SystemInformation::FindInformation() {
     auto details = mmotd::platform::GetSystemInformationDetails();
     if (!details.empty()) {
         CreateInformationObjects(details);
-        return true;
     }
-    return false;
 }
 
 void SystemInformation::CreateInformationObjects(const mmotd::platform::SystemDetails &details) {

--- a/lib/src/users_logged_in.cpp
+++ b/lib/src/users_logged_in.cpp
@@ -20,14 +20,11 @@ namespace mmotd::information {
 static const bool users_logged_in_factory_registered =
     RegisterInformationProvider([]() { return make_unique<mmotd::information::UsersLoggedIn>(); });
 
-bool UsersLoggedIn::FindInformation() {
+void UsersLoggedIn::FindInformation() {
     if (auto logged_in = GetUsersLoggedIn(); !logged_in.empty()) {
         auto logged = GetInfoTemplate(InformationId::ID_LOGGED_IN_USER_LOGGED_IN);
         logged.SetValueArgs(logged_in);
         AddInformation(logged);
-        return true;
-    } else {
-        return false;
     }
 }
 

--- a/lib/src/weather_info.cpp
+++ b/lib/src/weather_info.cpp
@@ -24,10 +24,10 @@ static constexpr const char *LOCATION = "Lehi UT US";
 static const bool users_logged_in_factory_registered =
     RegisterInformationProvider([]() { return make_unique<mmotd::information::WeatherInfo>(); });
 
-bool WeatherInfo::FindInformation() {
+void WeatherInfo::FindInformation() {
     auto [location_str, weather_str, sunrise_str, sunset_str] = GetWeatherInfo();
     if (empty(weather_str)) {
-        return false;
+        return;
     }
 
     auto weather = GetInfoTemplate(InformationId::ID_WEATHER_WEATHER);
@@ -47,14 +47,12 @@ bool WeatherInfo::FindInformation() {
     }
 
     if (empty(location_str)) {
-        return true;
+        return;
     }
 
     auto location = GetInfoTemplate(InformationId::ID_WEATHER_LOCATION);
     location.SetValueArgs(location_str);
     AddInformation(location);
-
-    return true;
 }
 
 pair<string, string> ParseSunriseSunset(string sunrise_str, string sunset_str) {


### PR DESCRIPTION
All objects which query for computer information are derived from the
InformationProvider abstract class.  They must all override the
FindInformation() function to query and set the computer information.
The class calls FindInformation() via the LookupInformation() method.
Both of these methods were returning bool but since the method is
being called via threads the result is always ignored.

These two methods should be changed to return void.

Closing issue #65 