### PR TITLE
Finish refactoring the throw and catch mechanism

### DIFF
--- a/apps/mmotd_raw/src/main.cpp
+++ b/apps/mmotd_raw/src/main.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "apps/mmotd_raw/include/main.h"
+#include "common/assertion/include/throw.h"
 #include "common/include/algorithm.h"
 #include "common/include/logging.h"
 #include "lib/include/computer_information.h"
@@ -81,19 +82,18 @@ int main_impl(int, char **argv) {
 
 int main(int argc, char *argv[]) {
     auto retval = EXIT_SUCCESS;
+    auto exception_message = string{};
+
     try {
         retval = main_impl(argc, argv);
     } catch (boost::exception &ex) {
-        auto diag = boost::diagnostic_information(ex);
-        LOG_FATAL("caught boost::exception in main: {}", diag);
-        retval = EXIT_FAILURE;
+        exception_message = mmotd::assertion::GetBoostExceptionMessage(ex);
     } catch (const std::exception &ex) {
-        auto diag = boost::diagnostic_information(ex);
-        LOG_FATAL("caught std::exception in main: {}", empty(diag) ? ex.what() : data(diag));
-        retval = EXIT_FAILURE;
-    } catch (...) {
-        auto diag = boost::current_exception_diagnostic_information();
-        LOG_FATAL("caught unknown exception in main: {}", diag);
+        exception_message = mmotd::assertion::GetStdExceptionMessage(ex);
+    } catch (...) { exception_message = mmotd::assertion::GetUnknownExceptionMessage(); }
+
+    if (!empty(exception_message)) {
+        LOG_FATAL("{}", exception_message);
         retval = EXIT_FAILURE;
     }
     return retval;

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,4 +1,4 @@
 # cmake/version.cmake
 set(MMOTD_MAJOR 0)
 set(MMOTD_MINOR 1)
-set(MMOTD_PATCHLEVEL 6-beta)
+set(MMOTD_PATCHLEVEL 7-beta)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -10,9 +10,9 @@ project (mmotd_common)
 
 add_library (
     ${MMOTD_TARGET_NAME} STATIC
-    assertion/src/assertion.cpp
     assertion/src/exception.cpp
     assertion/src/stack_trace.cpp
+    assertion/src/throw.cpp
     results/src/output_column.cpp
     results/src/output_column_indexes.cpp
     results/src/output_frame.cpp

--- a/common/assertion/include/assertion.h
+++ b/common/assertion/include/assertion.h
@@ -1,6 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
-
 #include "common/assertion/include/exception.h"
 #include "common/assertion/include/throw.h"
 #include "common/include/source_location.h"

--- a/common/assertion/include/throw.h
+++ b/common/assertion/include/throw.h
@@ -1,18 +1,14 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
-
-#include "common/assertion/include/assertion.h"
-#include "common/assertion/include/exception.h"
 #include "common/assertion/include/stack_trace.h"
 #include "common/include/source_location.h"
 
 #include <string>
+#include <string_view>
 
-#include <backward.hpp>
 #include <boost/exception/enable_error_info.hpp>
 #include <boost/exception/error_info.hpp>
 #include <boost/exception/exception.hpp>
-// #include <boost/exception/get_error_info.hpp>
 #include <boost/exception/info.hpp>
 #include <boost/throw_exception.hpp>
 
@@ -21,9 +17,7 @@ namespace mmotd::assertion {
 using throw_stack_trace = boost::error_info<struct tag_stacktrace, std::string>;
 
 template<typename T>
-void ThrowException(
-    T &&ex,
-    mmotd::source_location::SourceLocation source_location = mmotd::source_location::SourceLocation::current()) {
+[[noreturn]] inline void ThrowException(T &&ex, mmotd::source_location::SourceLocation source_location) {
     ::boost::throw_exception(::boost::enable_error_info(ex)
                              << ::boost::throw_function(source_location.function_name())
                              << ::boost::throw_file(source_location.file_name())
@@ -32,14 +26,24 @@ void ThrowException(
 }
 
 template<typename T>
-void ThrowException(
-    const T &ex,
-    mmotd::source_location::SourceLocation source_location = mmotd::source_location::SourceLocation::current()) {
+[[noreturn]] inline void ThrowException(const T &ex, mmotd::source_location::SourceLocation source_location) {
     ::boost::throw_exception(::boost::enable_error_info(ex)
                              << ::boost::throw_function(source_location.function_name())
                              << ::boost::throw_file(source_location.file_name())
                              << ::boost::throw_line(static_cast<int>(source_location.line()))
                              << throw_stack_trace(mmotd::assertion::GetStackTrace()));
 }
+
+std::string GetBoostExceptionMessage(const boost::exception &ex,
+                                     std::string_view context = std::string_view{},
+                                     const mmotd::source_location::SourceLocation &source_location =
+                                         mmotd::source_location::SourceLocation::current()) noexcept;
+std::string GetStdExceptionMessage(const std::exception &ex,
+                                   std::string_view context = std::string_view{},
+                                   const mmotd::source_location::SourceLocation &source_location =
+                                       mmotd::source_location::SourceLocation::current()) noexcept;
+std::string GetUnknownExceptionMessage(std::string_view context = std::string_view{},
+                                       const mmotd::source_location::SourceLocation &source_location =
+                                           mmotd::source_location::SourceLocation::current()) noexcept;
 
 } // namespace mmotd::assertion

--- a/common/assertion/src/assertion.cpp
+++ b/common/assertion/src/assertion.cpp
@@ -1,2 +1,0 @@
-// vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
-#include "common/assertion/include/assertion.h"

--- a/common/assertion/src/throw.cpp
+++ b/common/assertion/src/throw.cpp
@@ -1,0 +1,153 @@
+// vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/assertion/include/assertion.h"
+#include "common/assertion/include/throw.h"
+#include "common/include/logging.h"
+#include "common/include/source_location.h"
+
+#include <exception>
+#include <string>
+
+#include <backward.hpp>
+#include <boost/core/demangle.hpp>
+#include <boost/exception/diagnostic_information.hpp>
+#include <boost/exception/error_info.hpp>
+#include <boost/exception/get_error_info.hpp>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+using namespace std;
+using namespace std::literals;
+using mmotd::source_location::SourceLocation;
+
+namespace {
+
+SourceLocation GetExceptionLocation(const boost::exception &ex) noexcept {
+    const auto *file_thrown = boost::get_error_info<boost::throw_file>(ex);
+    const auto *function_thrown = boost::get_error_info<boost::throw_function>(ex);
+    const auto *line_thrown = boost::get_error_info<boost::throw_line>(ex);
+    if (file_thrown != nullptr && function_thrown != nullptr && line_thrown != nullptr) {
+        return SourceLocation{*file_thrown, *function_thrown, *line_thrown, long{0}};
+    } else {
+        return SourceLocation{nullptr, nullptr, long{0}, long{0}};
+    }
+}
+
+string GetExceptionBacktrace(const boost::exception &ex) noexcept {
+    const auto *backtrace_thrown = boost::get_error_info<mmotd::assertion::throw_stack_trace>(ex);
+    return backtrace_thrown != nullptr ? string{*backtrace_thrown} : string{};
+}
+
+string GetExceptionStr(const std::exception &ex) {
+    if (const auto *what_msg = ex.what(); what_msg != nullptr) {
+        return string{what_msg};
+    } else {
+        return boost::core::demangle(typeid(ex).name());
+    }
+}
+
+bool ContainsBacktrace(const string &msg) {
+    return msg.find("Stack trace (most recent call last):") != string::npos;
+}
+
+bool ContainsSourceLocation(const string &msg) {
+    auto source_location = mmotd::source_location::from_string(msg, " at ", "\\n");
+    return !empty(source_location);
+}
+
+string CreateExceptionMessage(const boost::exception &ex, const std::exception &std_ex) {
+    auto msg = fmt::format(FMT_STRING("{}"), std::quoted(GetExceptionStr(std_ex)));
+    if (!ContainsSourceLocation(msg)) {
+        if (auto throw_location = GetExceptionLocation(ex); !throw_location.empty()) {
+            msg += " at "s + to_string(throw_location);
+        }
+    }
+    if (!ContainsBacktrace(msg)) {
+        if (auto throw_backtrace = GetExceptionBacktrace(ex); !empty(throw_backtrace)) {
+            return msg + "\n"s + throw_backtrace;
+        }
+    }
+    return msg;
+}
+
+string CreateExceptionMessage(const std::exception &ex) {
+    return GetExceptionStr(ex);
+}
+
+string CreateExceptionMessage() {
+#if defined(__GLIBCXX__)
+    if (auto *info = std::current_exception().__cxa_exception_type(); info != nullptr) {
+        return string{boost::core::demangle(info->name())};
+    }
+#endif
+    return "<unknown exception>"s;
+}
+
+string GetBoostExceptionMessageImpl(const boost::exception &ex,
+                                    std::string_view context,
+                                    const SourceLocation &source_location) {
+    const auto *std_ex = dynamic_cast<const std::exception *>(&ex);
+    CHECKS(std_ex != nullptr, "impossible, all boost::exceptions must inherit from std::exception");
+    auto exception_msg = CreateExceptionMessage(ex, *std_ex);
+    auto function_name = mmotd::source_location::function_name_to_string(source_location);
+    if (empty(context)) {
+        return fmt::format(FMT_STRING("caught boost::exception in {}: {}"), function_name, exception_msg);
+    } else {
+        return fmt::format(FMT_STRING("caught boost::exception {} in {}: {}"), context, function_name, exception_msg);
+    }
+}
+
+string
+GetStdExceptionMessageImpl(const std::exception &ex, std::string_view context, const SourceLocation &source_location) {
+    const auto *boost_ex = dynamic_cast<const boost::exception *>(&ex);
+    // CHECKS(boost_ex != nullptr, "yeah that's possible, someone didn't use the ThrowException mechanism");
+    auto exception_msg = string{};
+    if (boost_ex != nullptr) {
+        exception_msg = CreateExceptionMessage(*boost_ex, ex);
+    } else {
+        exception_msg = CreateExceptionMessage(ex);
+    }
+    auto function_name = mmotd::source_location::function_name_to_string(source_location);
+    if (empty(context)) {
+        return fmt::format(FMT_STRING("caught std::exception in {}: {}"), function_name, exception_msg);
+    } else {
+        return fmt::format(FMT_STRING("caught std::exception {} in {}: {}"), context, function_name, exception_msg);
+    }
+}
+
+string GetUnknownExceptionMessageImpl(std::string_view context, const SourceLocation &source_location) {
+    auto exception_type = CreateExceptionMessage();
+    auto function_name = mmotd::source_location::function_name_to_string(source_location);
+    if (empty(context)) {
+        return fmt::format(FMT_STRING("caught unknown exception in {}: {}"), function_name, exception_type);
+    } else {
+        return fmt::format(FMT_STRING("caught unknown exception {} in {}: {}"), context, function_name, exception_type);
+    }
+}
+
+} // namespace
+
+namespace mmotd::assertion {
+
+string GetBoostExceptionMessage(const boost::exception &ex,
+                                std::string_view context,
+                                const SourceLocation &source_location) noexcept {
+    try {
+        return GetBoostExceptionMessageImpl(ex, context, source_location);
+    } catch (...) { return string{}; }
+}
+
+string GetStdExceptionMessage(const std::exception &ex,
+                              std::string_view context,
+                              const SourceLocation &source_location) noexcept {
+    try {
+        return GetStdExceptionMessageImpl(ex, context, source_location);
+    } catch (...) { return string{}; }
+}
+
+string GetUnknownExceptionMessage(std::string_view context, const SourceLocation &source_location) noexcept {
+    try {
+        return GetUnknownExceptionMessageImpl(context, source_location);
+    } catch (...) { return string{}; }
+}
+
+} // namespace mmotd::assertion

--- a/common/include/source_location.h
+++ b/common/include/source_location.h
@@ -25,14 +25,21 @@ struct SourceLocation {
     constexpr const char *function_name() const noexcept { return function_name_; }
     constexpr std::uint32_t line() const noexcept { return line_; }
     constexpr std::uint32_t column() const noexcept { return column_; }
+    constexpr bool empty() const noexcept {
+        return file_name_ == nullptr && function_name_ == nullptr && line_ == 0 && column_ == 0;
+    }
 
 private:
-    const char *file_name_ = "unknown";
-    const char *function_name_ = "unknown";
+    const char *file_name_ = nullptr;
+    const char *function_name_ = nullptr;
     std::uint32_t line_ = 0;
     std::uint32_t column_ = 0;
 };
 
+std::string file_name_to_string(const SourceLocation &location);
+std::string function_name_to_string(const SourceLocation &location);
+
+SourceLocation from_string(std::string input, std::string prefix = std::string{}, std::string suffix = std::string{});
 std::string to_string(const SourceLocation &location);
 std::ostream &operator<<(std::ostream &out, const SourceLocation &source_location);
 

--- a/common/results/src/output_frame.cpp
+++ b/common/results/src/output_frame.cpp
@@ -14,9 +14,14 @@
 #include "common/results/include/template_column_items.h"
 #include "common/results/include/template_string.h"
 
+#include <algorithm>
+#include <climits>
 #include <cstddef>
 #include <cstdlib>
 #include <iterator>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <boost/uuid/uuid_io.hpp>
 #include <fmt/color.h>
@@ -33,8 +38,6 @@ using mmotd::results::data::TemplateColumnItem;
 using mmotd::results::data::TemplateColumnItems;
 
 using namespace std;
-
-static constexpr const int INVALID_ROW = std::numeric_limits<int>::max();
 
 // namespace {
 
@@ -95,8 +98,6 @@ const Column &Frame::GetColumn(RowId row_id) const {
         }
     }
     THROW_OUT_OF_RANGE("row id {} not found in any columns", row_id);
-    static const auto INVALID_COLUMN = Column{};
-    return INVALID_COLUMN;
 }
 
 Column &Frame::GetColumn(RowId row_id) {
@@ -107,8 +108,6 @@ Column &Frame::GetColumn(RowId row_id) {
         }
     }
     THROW_OUT_OF_RANGE("row id {} not found in any columns", row_id);
-    static auto INVALID_COLUMN = Column{};
-    return INVALID_COLUMN;
 }
 
 size_t Frame::GetRowValueInformationIdCount(const string &value, const Informations &informations) const {
@@ -261,7 +260,7 @@ string Frame::CreateTable() const {
 }
 
 RowNumberSentinals Frame::GetFirstLastRowNumbers() const {
-    auto first_row_number = INVALID_ROW;
+    auto first_row_number = std::numeric_limits<int>::max();
     auto last_row_number = 0;
     for (auto index : GetColumnIndexes()) {
         auto sentinals = GetColumn(index).GetFirstLastRowNumbers();

--- a/common/src/source_location.cpp
+++ b/common/src/source_location.cpp
@@ -2,25 +2,65 @@
 #include "common/include/source_location.h"
 #include "common/include/source_location_common.h"
 
+#include <charconv>
 #include <ostream>
+#include <regex>
 
+#include <boost/algorithm/string.hpp>
 #include <fmt/format.h>
 
 using namespace std;
 
+namespace {
+
+template<typename T>
+T to_integer(string input) {
+    T number{};
+    auto [ptr, ec] = std::from_chars(data(input), &input[size(input)], number);
+    return ec == std::errc{} ? number : T{};
+}
+
+mmotd::source_location::SourceLocation
+from_string_impl(string input, string prefix = string{}, string suffix = string{}) {
+    static const char *const pattern_str = R"(([-_\w\d\.]+(?:cpp|cc|c|hpp|hh|h|inl|i)?(?=@))@([^#]+)#(\d+):(\d+))";
+    // fix_todo_jasoni: this is a very bad idea... taking random input from client and creating regex pattern
+    auto pattern = prefix + pattern_str + suffix;
+    auto source_location_regex = std::regex{pattern, regex::ECMAScript};
+    auto matches = smatch{};
+    if (regex_search(input, matches, source_location_regex) && matches.size() >= 5) {
+        auto file_name = matches[1].str();
+        auto function_name = matches[2].str();
+        auto line_number = to_integer<long>(matches[3].str());
+        auto column_number = to_integer<long>(matches[4].str());
+        return mmotd::source_location::SourceLocation(data(file_name), data(function_name), line_number, column_number);
+    }
+    return mmotd::source_location::SourceLocation();
+}
+
+} // namespace
+
 namespace mmotd::source_location {
 
+string file_name_to_string(const SourceLocation &location) {
+    return TrimFileName(location.file_name());
+}
+
+string function_name_to_string(const SourceLocation &location) {
+    return TrimFunction(location.function_name(), FunctionArgStrategy::replace, FunctionReturnStrategy::remove);
+}
+
+SourceLocation from_string(string input, string prefix, string suffix) {
+    return from_string_impl(input, prefix, suffix);
+}
+
 string to_string(const SourceLocation &location) {
-    auto function_name =
-        TrimFunction(location.function_name(), FunctionArgStrategy::replace, FunctionReturnStrategy::remove);
-    auto line_number = location.line();
-    auto result = TrimFileName(location.file_name());
+    auto result = file_name_to_string(location);
     if (!empty(result)) {
         result += '@';
     }
-    result += function_name;
-    if (line_number != 0) {
-        result += string{"#"} + ::to_string(line_number);
+    result += function_name_to_string(location);
+    if (location.line() != 0) {
+        result += fmt::format(FMT_STRING("#{}:{}"), location.line(), location.column());
     }
     return result;
 }

--- a/common/test/src/test_assertion.cpp
+++ b/common/test/src/test_assertion.cpp
@@ -20,7 +20,7 @@ void PreconditionSuccess() {
     PRECONDITIONS(true, "PRECONDITIONS does not throw when expression is true");
 }
 
-void PreconditionFail() {
+[[noreturn]] void PreconditionFail() {
     PRECONDITIONS(false, "PRECONDITIONS throws when expression is false");
 }
 
@@ -28,7 +28,7 @@ void CheckSuccess() {
     CHECKS(true, "CHECKS does not throw when expression is true");
 }
 
-void CheckFail() {
+[[noreturn]] void CheckFail() {
     CHECKS(false, "CHECKS throws when expression is false");
 }
 
@@ -36,7 +36,7 @@ void PostconditionSuccess() {
     POSTCONDITIONS(true, "POSTCONDITIONS does not throw when expression is true");
 }
 
-void PostconditionFail() {
+[[noreturn]] void PostconditionFail() {
     POSTCONDITIONS(false, "POSTCONDITIONS throws when expression is false");
 }
 

--- a/lib/src/information_provider.cpp
+++ b/lib/src/information_provider.cpp
@@ -1,4 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/assertion/include/throw.h"
 #include "common/include/information.h"
 #include "common/include/information_decls.h"
 #include "common/include/information_definitions.h"
@@ -9,12 +10,14 @@
 #include <iterator>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <boost/exception/diagnostic_information.hpp>
 #include <fmt/format.h>
 
 using namespace std;
+using namespace std::string_literals;
 
 namespace mmotd::information {
 
@@ -27,14 +30,18 @@ const std::vector<Information> &InformationProvider::GetInformations() const {
 }
 
 void InformationProvider::LookupInformation() {
+    auto exception_message = string{};
+
     try {
         FindInformation();
     } catch (boost::exception &ex) {
-        auto diag = boost::diagnostic_information(ex);
-        LOG_ERROR("caught boost::exception in LookupInformation: {}", diag);
+        exception_message = mmotd::assertion::GetBoostExceptionMessage(ex);
     } catch (const std::exception &ex) {
-        auto diag = boost::diagnostic_information(ex);
-        LOG_ERROR("caught std::exception in LookupInformation: {}", empty(diag) ? ex.what() : data(diag));
+        exception_message = mmotd::assertion::GetStdExceptionMessage(ex);
+    } catch (...) { exception_message = mmotd::assertion::GetUnknownExceptionMessage(); }
+
+    if (!empty(exception_message)) {
+        LOG_ERROR("{}", exception_message);
     }
 }
 


### PR DESCRIPTION
This builds upon the work done in [Pull Request #75].  That pull request sorted out many of the use cases when the client is trying to figure out how to throw an exception.  It made the documentation clear that all `throw`-ing should be done via the functions inside `common/assertion/include/throw.h`.

This Pull Request then finishes the exception hand-off by refactoring the `catch` locations to ensure they all have just 1 API to call to translate an exception into an error string.

Closes #71 