### PR TITLE
Add additional config options and defaults

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -28,7 +28,7 @@ BinPackParameters: false
 BitFieldColonSpacing: Both
 BraceWrapping:
   AfterCaseLabel:  false
-  AfterClass:      true
+  AfterClass:      false
   AfterControlStatement: Never
   AfterEnum:       false
   AfterFunction:   false

--- a/.vscode/mmotd.code-workspace
+++ b/.vscode/mmotd.code-workspace
@@ -118,6 +118,7 @@
 		"cmake.reconfigureOnChange": true,
 		"cmake.default.env": {
 			"CMAKE_BUILD_TYPE": "Debug"
-		}
+		},
+		"cmake.copyCompileCommands": "${workspaceFolder}/compile_commands.json"
 	}
 }

--- a/apps/mmotd/src/main.cpp
+++ b/apps/mmotd/src/main.cpp
@@ -6,6 +6,7 @@
 #include "common/include/cli_options_parser.h"
 #include "common/include/config_options.h"
 #include "common/include/logging.h"
+#include "common/include/special_files.h"
 #include "common/results/include/output_template.h"
 #include "common/results/include/output_template_printer.h"
 #include "lib/include/computer_information.h"
@@ -29,12 +30,13 @@ namespace {
 
 void PrintMmotd() {
     using namespace mmotd::results;
+    using mmotd::core::special_files::ExpandEnvironmentVariables;
 
-    const auto template_filename = ConfigOptions::Instance().GetValueAsStringOr("cli.template_path", string{});
+    const auto template_filename = ConfigOptions::Instance().GetValueAsStringOr("template_path", string{});
     LOG_INFO("template file name: {}", quoted(template_filename));
     auto output_template = unique_ptr<OutputTemplate>{};
     if (!empty(template_filename)) {
-        output_template = MakeOutputTemplate(template_filename);
+        output_template = MakeOutputTemplate(ExpandEnvironmentVariables(template_filename));
     } else {
         output_template = MakeOutputTemplateFromDefault();
     }
@@ -52,7 +54,7 @@ void PrintMmotd() {
 }
 
 void UpdateLogSeverity() {
-    const auto log_severity_raw = ConfigOptions::Instance().GetValueAsIntegerOr("cli.log_severity", -1);
+    const auto log_severity_raw = ConfigOptions::Instance().GetValueAsIntegerOr("log_severity", -1);
     if (log_severity_raw == -1) {
         return;
     }

--- a/cmake/find_dependencies.cmake
+++ b/cmake/find_dependencies.cmake
@@ -35,7 +35,7 @@ endif ()
 option (BUILD_TZ_LIB "build/install of TZ library" ON)
 FetchContent_Declare(date
     GIT_REPOSITORY   https://github.com/HowardHinnant/date.git
-    GIT_TAG          v3.0.0
+    GIT_TAG          v3.0.1
 )
 set(MESSAGE_QUIET ON)
 FetchContent_MakeAvailable(date)
@@ -44,7 +44,7 @@ unset(MESSAGE_QUIET)
 # Component: Backward.  Stack trace library
 FetchContent_Declare(Backward
     GIT_REPOSITORY   https://github.com/bombela/backward-cpp.git
-    #GIT_TAG          v1.5
+    GIT_TAG          v1.6
 )
 set(MESSAGE_QUIET ON)
 FetchContent_MakeAvailable(Backward)
@@ -67,14 +67,14 @@ endif ()
 # Component: Catch2.  Unit testing framework
 FetchContent_Declare(catch2
     GIT_REPOSITORY   https://github.com/catchorg/Catch2.git
-    GIT_TAG          v2.13.4
+    GIT_TAG          v2.13.7
 )
 FetchContent_MakeAvailable(catch2)
 
 # Component: json.  The lightweight repository of nlohmann/json which provides json support.
 FetchContent_Declare(json
     GIT_REPOSITORY   https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent
-    GIT_TAG          v3.9.1
+    GIT_TAG          v3.10.4
 )
 FetchContent_GetProperties(json)
 if(NOT json_POPULATED)
@@ -126,10 +126,7 @@ endif ()
 #                    complexity needed for a project of this scale.
 FetchContent_Declare(cli11
     GIT_REPOSITORY   https://github.com/CLIUtils/CLI11.git
-    # The git tag of 'v1.9.1' is actually valid.  But I started using HEAD and now I am reliant
-    #  on a few of the features there.  Once CLI11 creates a new release I will update this
-    #  rely on that tag
-    #GIT_TAG         v1.9.1
+    GIT_TAG          v2.1.1
 )
 FetchContent_GetProperties(cli11)
 if (NOT cli11_POPULATED)
@@ -166,7 +163,7 @@ endif ()
 #                      5. ... and the non-trivial concept of seeding (i.e when, how, how often, etc.)
 FetchContent_Declare(random
     GIT_REPOSITORY   https://github.com/effolkronium/random.git
-    GIT_TAG          v1.3.1
+    GIT_TAG          v1.4.0
 )
 FetchContent_GetProperties(random)
 if (NOT random_POPULATED)

--- a/cmake/target_common.cmake
+++ b/cmake/target_common.cmake
@@ -71,19 +71,14 @@ macro (setup_target_properties MMOTD_TARTET_NAME PROJECT_ROOT_INCLUDE_PATH)
         # If this config identifier is defined then all CATCH macros are prefixed with CATCH_
         # This enables the MMOTD project to define it's own version of 'CHECK'
         PRIVATE CATCH_CONFIG_PREFIX_ALL
-        # This disables the BOOST_ASSERT macro and the "boost::assertion_failed",
-        #  "boost::assertion_failed_msg" functions
-        # PRIVATE BOOST_DISABLE_ASSERTS
         # When defined and compiler language is set to `-std=c++17` or higher,
         #  the lambda passed to scope_guard is required to be specified as `noexcept`.
         PRIVATE SG_REQUIRE_NOEXCEPT_IN_CPP17
-        # Avoids a compiler warning where the boost::placeholders::_1, _2, _3, etc. end up
-        #  conflicting with the ones in the standard C++ library as they are unintendedly
-        #  loaded into the global namespace (doh!).
-        PRIVATE $<$<CXX_COMPILER_ID:GNU>:BOOST_BIND_GLOBAL_PLACEHOLDERS=1>
         # FMT_ENFORCE_COMPILE_STRING requires all format strings to use FMT_STRING which enables
         #  compile time checking of the format string against the arguments.
         PRIVATE FMT_ENFORCE_COMPILE_STRING
+        # Boost ASIO has not updated it's code for C++20 and the removal of `std::result_of`
+        PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang>:BOOST_ASIO_HAS_STD_INVOKE_RESULT>
         # When defined the discovery of system properties will be done serially
         #PRIVATE MMOTD_ASYNC_DISABLED
         )
@@ -130,6 +125,7 @@ macro (setup_target_properties MMOTD_TARTET_NAME PROJECT_ROOT_INCLUDE_PATH)
         PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Wmost>
         PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Wweak-vtables>
         PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Wmissing-noreturn>
+        PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Wdtor-name>
         # gnu only
         PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wtrampolines>
         PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wlogical-op>

--- a/common/include/algorithm.h
+++ b/common/include/algorithm.h
@@ -5,13 +5,16 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <functional>
 #include <iterator>
 #include <limits>
+#include <sstream>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace mmotd::algorithms {
 
@@ -148,6 +151,54 @@ inline std::string join(const Container &container, Seperator seperator, Func fu
         output += func(*i);
     }
     return output;
+}
+
+template<class Container, class Seperator, class Func, class Pred>
+inline std::string join_if(const Container &container, Seperator seperator, Func func, Pred pred) {
+    auto output = std::string{};
+    auto end = std::end(container);
+    for (auto i = std::begin(container); i != end; ++i) {
+        const auto &element = func(*i);
+        if (pred(element)) {
+            if (std::distance(std::begin(container), i) != 0 && std::distance(i, end) != 1) {
+                output += seperator;
+            }
+            output += element;
+        }
+    }
+    return output;
+}
+
+//
+// This is a simple formatting function which takes an `input` string and splits
+//  it on whitespace. From there it creates lines of `output` text `max_length`
+//  in size.  These lines are seperated by a newline `\n` character and returned.
+// This algorithm should be refactored to take the `char` or `set of chars` to
+//  initially split the string.  It should also take a `char` or `string` which
+//  is should be used to join the `max_length` strings:
+//   example:
+//   string split_sentence(string input, string split_chars, size_t max_length, string join_chars);
+//
+inline std::string split_sentence(std::string input, std::size_t max_length) {
+    if (empty(input) || max_length >= std::size(input)) {
+        return input;
+    }
+    auto input_stream = std::istringstream{input};
+    auto chunks = std::vector<std::string>{std::istream_iterator<std::string>{input_stream},
+                                           std::istream_iterator<std::string>()};
+    auto joined_chunks = std::vector<std::string>{};
+    for (const auto &chunk : chunks) {
+        if (size(chunk) >= max_length) {
+            joined_chunks.push_back(chunk);
+        } else if (std::empty(joined_chunks)) {
+            joined_chunks.push_back(chunk);
+        } else if (size(joined_chunks.back()) + 1ull + size(chunk) >= max_length) {
+            joined_chunks.push_back(chunk);
+        } else {
+            joined_chunks.back() += std::string{" "} + chunk;
+        }
+    }
+    return mmotd::algorithms::join(joined_chunks, "\n", [](const auto &i) { return i; });
 }
 
 //

--- a/common/include/chrono_io.h
+++ b/common/include/chrono_io.h
@@ -1,7 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
-#include "common/assertion/include/assertion.h"
-#include "common/include/logging.h"
+#include "common/include/config_options.h"
 
 #include <chrono>
 #include <cstdlib>
@@ -19,6 +18,27 @@ namespace mmotd::chrono::io {
 
 namespace detail {
 
+inline std::string GetTimeZoneStr() {
+    using namespace mmotd::core;
+    static auto time_zone_str = std::string{};
+    if (std::empty(time_zone_str)) {
+        time_zone_str = ConfigOptions::Instance().GetValueAsStringOr("timezone", std::string{});
+    }
+    return time_zone_str;
+}
+
+inline const date::time_zone *GetTimeZone() {
+    auto time_zone_str = GetTimeZoneStr();
+    const date::time_zone *tz = nullptr;
+    if (!std::empty(time_zone_str)) {
+        tz = date::locate_zone(time_zone_str);
+    }
+    if (tz == nullptr) {
+        tz = date::current_zone();
+    }
+    return tz;
+}
+
 inline std::string to_string(date::time_of_day<std::chrono::seconds> tod, const char *chrono_format) {
     auto fields = date::fields{tod};
     auto result = date::format(chrono_format, fields);
@@ -35,7 +55,7 @@ inline std::string to_string(date::time_of_day<std::chrono::seconds> tod, const 
 
 template<class Clock, class Duration>
 inline std::string to_string(std::chrono::time_point<Clock, Duration> time_point, const char *chrono_format) {
-    auto time_point_zoned = date::make_zoned(date::locate_zone("America/Denver"), time_point);
+    auto time_point_zoned = date::make_zoned(GetTimeZone(), time_point);
     auto result = date::format(chrono_format, time_point_zoned);
     if (auto am_index = result.rfind("AM"); am_index != std::string::npos) {
         result[am_index] = 'a';
@@ -54,34 +74,23 @@ inline auto from_string(std::string input, const char *chrono_format) {
     std::istringstream stream{input};
     stream >> date::parse(chrono_format, seconds_since_midnight);
     auto tod = date::make_time(seconds_since_midnight);
-    LOG_VERBOSE("parsed time: {}, using format: {}, from string: '{}'", tod, chrono_format, input);
-    if (stream.fail()) {
-        LOG_ERROR("failed to parse string: '{}', using format: {}", input, chrono_format);
-    }
     return !stream.fail() ? std::make_optional(tod) : std::nullopt;
 }
 
 inline std::optional<std::size_t> get_current_hour() {
-    auto now_time_point = date::make_zoned(date::locate_zone("America/Denver"), std::chrono::system_clock::now());
+    auto now_time_point = date::make_zoned(GetTimeZone(), std::chrono::system_clock::now());
     auto hour_str = date::format("%H", now_time_point);
     const auto &loc = std::locale();
     if (size(hour_str) != std::size_t{2}) {
-        LOG_ERROR("hour is not two digit characters: '{}', current time: '{}'", hour_str, now_time_point);
         return std::nullopt;
     } else if (!std::isdigit(hour_str.front(), loc) || !std::isdigit(hour_str.back(), loc)) {
-        LOG_ERROR("hour is not digit characters: '{}', current time: '{}'", hour_str, now_time_point);
         return std::nullopt;
     } else {
         if (hour_str.front() == '0') {
             hour_str = hour_str.substr(1);
         }
         auto hour = stoull(hour_str, nullptr, 10);
-        LOG_VERBOSE("current hour: '{}', current time: '{}'", hour, now_time_point);
         if (hour > 23) {
-            LOG_VERBOSE("current hour: {}, is larger than valid max: 23, clamping to max: {}, current time: '{}'",
-                        hour,
-                        std::size_t{23},
-                        now_time_point);
             hour = std::size_t{23};
         }
         return {hour};
@@ -92,6 +101,7 @@ inline std::optional<std::size_t> get_current_hour() {
 
 using detail::from_string;
 using detail::get_current_hour;
+using detail::GetTimeZone;
 using detail::to_string;
 
 } // namespace mmotd::chrono::io

--- a/common/include/cli_options_parser.h
+++ b/common/include/cli_options_parser.h
@@ -34,8 +34,8 @@ private:
     void AddOptionsToSubCommand(CLI::App &app);
     void AddOptionDeclarations(CLI::App &app);
 
-    static void WriteDefaultConfiguration(std::filesystem::path file_path, std::string app_config);
-    static void WriteDefaultTemplate(std::filesystem::path file_path);
+    static bool WriteDefaultConfiguration(std::filesystem::path file_path);
+    static bool WriteDefaultTemplate(std::filesystem::path file_path);
 
     std::unique_ptr<CliOptions> options_;
 };

--- a/common/include/config_options.h
+++ b/common/include/config_options.h
@@ -1,3 +1,4 @@
+// vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
 #include "common/include/big_five_macros.h"
 
@@ -14,12 +15,18 @@ namespace mmotd::core {
 
 class ConfigOptions {
 public:
-    DEFAULT_CONSTRUCTORS_COPY_MOVE_OPERATORS_DESTRUCTOR(ConfigOptions);
+    NO_CONSTRUCTOR_DEFAULT_COPY_MOVE_OPERATORS_DESTRUCTOR(ConfigOptions);
 
+    // The `reinitialize = true` parameter is only to be used by the unit-tests
     static ConfigOptions &Instance(bool reinitialize = false);
+
     void ParseConfigFile(std::filesystem::path file_path);
-    void ParseConfigFile(std::istream &input, const std::string &file_name);
-    void AddCliConfigOptions(std::istream &input);
+
+    // This method is only to be used by the unit-tests
+    void ParseConfigFile(std::istream &input);
+
+    template<typename T>
+    void AddConfigOption(std::string name, T value);
 
     bool Contains(const std::string &name) const;
 
@@ -35,22 +42,22 @@ public:
     std::optional<std::string> GetValueAsString(const std::string &name) const noexcept;
     std::string GetValueAsStringOr(const std::string &name, std::string default_value) const noexcept;
 
+    bool WriteDefaultConfigOptions(std::filesystem::path file_path) const;
     std::string to_string() const;
 
-    static constexpr std::string_view CORE_TABLE = "core";
-    static constexpr std::string_view CLI_TABLE = "cli";
-
 private:
+    ConfigOptions();
+
     toml::value FindValue(std::string input_name) const;
-    void InitializeConfigPath();
-    void InitializeTemplatePath();
-    std::string GetConfigPath() const noexcept { return config_path_; }
-    std::string GetTemplatePath() const noexcept { return template_path_; }
 
     toml::value core_value_;
-    toml::value cli_value_;
-    std::string config_path_;
-    std::string template_path_;
 };
+
+template<typename T>
+void ConfigOptions::AddConfigOption(std::string name, T value) {
+    if (core_value_.is_table()) {
+        core_value_[name] = value;
+    }
+}
 
 } // namespace mmotd::core

--- a/common/include/special_files.h
+++ b/common/include/special_files.h
@@ -3,13 +3,21 @@
 #include <filesystem>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace mmotd::core::special_files {
+
+std::filesystem::path FindProjectRootDirectory();
+std::string GetEnvironmentValue(std::string variable_name);
+std::string ExpandEnvironmentVariables(std::string input);
 
 bool IsStdoutTty();
 
 constexpr const std::string_view CONFIG_FILENAME = "mmotd_config.toml";
 constexpr const std::string_view TEMPLATE_FILENAME = "mmotd_template.json";
+
+std::vector<std::filesystem::path> GetDefaultLocations();
+std::string GetDefaultLocationsStr();
 
 std::filesystem::path FindFileInDefaultLocations(std::string_view file_name);
 

--- a/common/results/include/output_template.h
+++ b/common/results/include/output_template.h
@@ -56,6 +56,6 @@ void to_json(nlohmann::json &root, const OutputTemplate &output_template);
 
 std::unique_ptr<OutputTemplate> MakeOutputTemplate(std::string file_name);
 std::unique_ptr<OutputTemplate> MakeOutputTemplateFromDefault();
-void WriteDefaultOutputTemplate(std::filesystem::path file_path);
+bool WriteDefaultOutputTemplate(std::filesystem::path file_path);
 
 } // namespace mmotd::results

--- a/common/results/src/output_template.cpp
+++ b/common/results/src/output_template.cpp
@@ -344,7 +344,7 @@ unique_ptr<OutputTemplate> MakeOutputTemplateFromDefault() {
     return make_unique<OutputTemplate>();
 }
 
-void WriteDefaultOutputTemplate(fs::path file_path) {
+bool WriteDefaultOutputTemplate(fs::path file_path) {
     auto output_template = OutputTemplate{};
     auto root = json{};
     to_json(root, output_template);
@@ -352,9 +352,10 @@ void WriteDefaultOutputTemplate(fs::path file_path) {
     auto output = ofstream(file_path);
     if (!output.is_open()) {
         LOG_ERROR("unable to open '{}' for writing output template", file_path);
-        return;
+        return false;
     }
     output << root.dump(2, ' ') << endl;
+    return true;
 }
 
 } // namespace mmotd::results

--- a/common/results/src/template_string.cpp
+++ b/common/results/src/template_string.cpp
@@ -34,8 +34,8 @@ using mmotd::results::data::TemplateColumnItem;
 namespace mmotd::results {
 
 TemplateString::TemplateString(std::string text, fmt::text_style color_style) :
-    text_(std::move(text)), color_style_(color_style) {
-}
+    text_(std::move(text)),
+    color_style_(color_style) {}
 
 optional<Information> TemplateString::FindInformation(const string &information_id,
                                                       const Informations &informations,
@@ -321,7 +321,7 @@ fmt::text_style TemplateString::GetColorValue(string color_specification) {
 string TemplateString::ReplaceEmbeddedColorCodes(const string &text, fmt::text_style color_style) {
     auto template_substrings = TemplateString::GenerateTemplateSubstrings(text);
     auto formatted_str = template_substrings.to_string(&TemplateString::GetColorValue);
-    static const auto color_output = ConfigOptions::Instance().GetValueAsBooleanOr("cli.color_output", false);
+    static const auto color_output = ConfigOptions::Instance().GetValueAsBooleanOr("color_output", false);
     return color_output ? format(color_style, FMT_STRING("{}"), formatted_str) : formatted_str;
 }
 

--- a/common/results/src/template_substring.cpp
+++ b/common/results/src/template_substring.cpp
@@ -134,7 +134,7 @@ string TemplateSubstring::to_string(function<fmt::text_style(string)> convert_co
                 color_definitions_to_string(GetColorDefinitions()),
                 GetSubstring(),
                 GetSuffix());
-    static const auto color_output = ConfigOptions::Instance().GetValueAsBooleanOr("cli.color_output", false);
+    static const auto color_output = ConfigOptions::Instance().GetValueAsBooleanOr("color_output", false);
 
     if (!color_output) {
         return RemoveNonAsciiCharsCopy(GetPrefix() + GetSubstring() + GetSuffix());

--- a/common/src/config_options.cpp
+++ b/common/src/config_options.cpp
@@ -1,8 +1,5 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
-#include "common/assertion/include/assertion.h"
 #include "common/include/config_options.h"
-#include "common/include/logging.h"
-#include "common/include/special_files.h"
 
 #include <algorithm>
 #include <deque>
@@ -15,7 +12,6 @@
 #include <optional>
 #include <queue>
 #include <system_error>
-#include <variant>
 
 #include <boost/algorithm/string.hpp>
 #include <fmt/format.h>
@@ -31,162 +27,77 @@ using fmt::format;
 
 namespace {
 
-bool IsRequestingConfigPath(string name) {
-    return name == "config_path" || boost::ends_with(name, ".config_path");
+auto GetDefaultCoreValue() -> toml::value {
+    using namespace toml::literals::toml_literals;
+    return u8R"(
+#
+# modified message of the day
+#
+
+# Enabling this may cause a performance cost. Every write to the log file will be flushed
+#  when set to 'true'. This disables the natural file output caching of log file writes and
+#  may enable seeing more debug statements before a crash.
+logging_flush=false
+
+# Replace the following with the location of where your "mmotd_template.json" exists
+# template_path="$HOME/.config/mmotd/mmotd_template.json"
+
+# This is the same value that is the last couple of segments of the file linked to /etc/localtime
+# /var/db/timezone/zoneinfo/America/Denver
+timezone="America/Denver"
+
+# The following three values are used to look-up the local whether, http://wttr.in/Albuquerque%20NM%20USA
+city="Albuquerque"
+state="NM"
+country="USA"
+)"_toml;
 }
 
-bool IsRequestingTemplatePath(string name) {
-    return name == "template_path" || boost::ends_with(name, ".template_path");
-}
-
-toml::value FindValueInTable(const toml::value &root_value, queue<string> names) {
-    PRECONDITIONS(!root_value.is_uninitialized(), "unable to find value when the root is uninitialized");
-    PRECONDITIONS(size(names) >= 2, "the names queue must have atleast two values (root and value to find)");
-
-    const toml::value *result_ptr = nullptr;
-    do {
+toml::value FindValueImpl(const toml::value &toml_value, queue<string> names) {
+    const toml::value *result_ptr = &toml_value;
+    while (!empty(names) && result_ptr != nullptr) {
         const auto name = names.front();
         names.pop();
-        if (result_ptr == nullptr) {
-            result_ptr = &root_value;
-        } else if (result_ptr->is_table() && result_ptr->contains(name)) {
+        if (result_ptr->is_table() && result_ptr->contains(name)) {
             const auto &value_ref = toml::find(*result_ptr, name);
             result_ptr = &value_ref;
         } else {
             result_ptr = nullptr;
         }
-    } while (!empty(names) && result_ptr != nullptr);
-
+    }
     return result_ptr == nullptr ? toml::value{} : *result_ptr;
-}
-
-toml::value FindValueImpl(const toml::value &core, const toml::value &cli, queue<string> names) {
-    using mmotd::core::ConfigOptions;
-    PRECONDITIONS(!empty(names), "the queue of names should never be empty");
-    const auto &search_table = names.front() == ConfigOptions::CORE_TABLE ? core : cli;
-    return FindValueInTable(search_table, names);
-}
-
-fs::path FindPath(const toml::value &root, string name) {
-    using namespace mmotd::core::special_files;
-    PRECONDITIONS(root.is_table(), "toml root value must always be a table, not {}", root.type());
-
-    if (!root.contains(name) || !root.at(name).is_string()) {
-        LOG_ERROR("root toml::value does not contain {} or it is not a string", quoted(name));
-        return fs::path{};
-    }
-
-    const auto &path_str = root.at(name).as_string().str;
-    if (empty(path_str)) {
-        LOG_DEBUG("root toml::value[{}] is an empty string", quoted(name));
-    } else {
-        auto path = fs::path(path_str);
-        auto ec = error_code{};
-        if (fs::exists(path, ec) && !ec) {
-            return path;
-        } else {
-            LOG_DEBUG("root toml::value[{}] is {}, but the file is not found", quoted(name), quoted(path.string()));
-        }
-    }
-
-    return fs::path{};
-}
-
-fs::path LocateConfigPath(const toml::value &core) {
-    using namespace mmotd::core::special_files;
-    auto config_path = core.is_uninitialized() ? fs::path{} : FindPath(core, "config_path"s);
-    if (empty(config_path)) {
-        return FindFileInDefaultLocations(CONFIG_FILENAME);
-    }
-    return config_path;
-}
-
-fs::path LocateTemplatePath(const toml::value &cli, const toml::value &core) {
-    using namespace mmotd::core::special_files;
-    auto cli_template_path = cli.is_uninitialized() ? fs::path{} : FindPath(cli, "template_path"s);
-    auto core_template_path = core.is_uninitialized() ? fs::path{} : FindPath(core, "template_path"s);
-    if (empty(cli_template_path) && empty(core_template_path)) {
-        return FindFileInDefaultLocations(TEMPLATE_FILENAME);
-    } else if (!empty(cli_template_path) && !empty(core_template_path)) {
-        return cli_template_path;
-    } else if (!empty(cli_template_path)) {
-        return cli_template_path;
-    } else {
-        return core_template_path;
-    }
 }
 
 } // namespace
 
 namespace mmotd::core {
 
+ConfigOptions::ConfigOptions() : core_value_(GetDefaultCoreValue()) {}
+
 ConfigOptions &ConfigOptions::Instance(bool reinitialize) {
-    static auto config_options_ptr = make_unique<ConfigOptions>();
+    static auto config_options_ptr = unique_ptr<ConfigOptions>(new ConfigOptions);
     if (reinitialize) {
-        auto new_config_options_ptr = make_unique<ConfigOptions>();
-        std::swap(config_options_ptr, new_config_options_ptr);
+        auto auto_ptr = unique_ptr<ConfigOptions>(new ConfigOptions);
+        std::swap(config_options_ptr, auto_ptr);
     }
     return *config_options_ptr;
 }
 
 void ConfigOptions::ParseConfigFile(fs::path file_path) {
-    LOG_VERBOSE("parsing config file: {}", file_path);
-    auto ec = error_code{};
-    if (!fs::exists(file_path, ec) || ec) {
-        ALWAYS_FAIL("config file '{}' does not exist", file_path);
-    }
     core_value_ = toml::parse(file_path);
-    LOG_VERBOSE("\nconfig options:\n{}", to_string());
 }
 
-void ConfigOptions::ParseConfigFile(istream &input, const string &file_name) {
-    LOG_VERBOSE("parsing config file: {}", file_name);
-    core_value_ = toml::parse(input, file_name);
-    LOG_VERBOSE("\nconfig options:\n{}", to_string());
-}
-
-void ConfigOptions::AddCliConfigOptions(istream &input) {
-    CHECKS(cli_value_.is_uninitialized(), "CLI options are added once as a toml stream");
-    cli_value_ = toml::parse(input, "cli-options.toml");
-    InitializeConfigPath();
-    if (!empty(GetConfigPath())) {
-        ParseConfigFile(GetConfigPath());
-    }
-    InitializeTemplatePath();
-    LOG_VERBOSE("\nconfig options:\n{}", to_string());
-}
-
-void ConfigOptions::InitializeConfigPath() {
-    config_path_ = LocateConfigPath(cli_value_);
-    LOG_VERBOSE("config path: {}", quoted(config_path_));
-}
-
-void ConfigOptions::InitializeTemplatePath() {
-    template_path_ = LocateTemplatePath(cli_value_, core_value_);
-    LOG_VERBOSE("template path: {}", quoted(template_path_));
+void ConfigOptions::ParseConfigFile(std::istream &input) {
+    core_value_ = toml::parse(input);
 }
 
 toml::value ConfigOptions::FindValue(string input_name) const {
     if (empty(input_name)) {
-        LOG_ERROR("unable to search for config option with an empty name");
         return toml::value{};
-    } else if (IsRequestingConfigPath(input_name)) {
-        LOG_VERBOSE("requesting config path: {}", quoted(GetConfigPath()));
-        return toml::value(GetConfigPath());
-    } else if (IsRequestingTemplatePath(input_name)) {
-        LOG_VERBOSE("requesting template path: {}", quoted(GetTemplatePath()));
-        return toml::value(GetTemplatePath());
     }
-
     auto names_deque = deque<string>{};
-    boost::split(names_deque, input_name, boost::is_any_of("."), boost::token_compress_on);
-    CHECKS(!empty(names_deque), "splitting {} on '.' must have at least one value", quoted(input_name));
-
-    if (names_deque.front() != ConfigOptions::CORE_TABLE && names_deque.front() != ConfigOptions::CLI_TABLE) {
-        names_deque.push_front(string{ConfigOptions::CORE_TABLE});
-    }
-
-    return FindValueImpl(core_value_, cli_value_, queue<string>{std::move(names_deque)});
+    boost::split(names_deque, input_name, boost::is_any_of("."));
+    return FindValueImpl(core_value_, queue<string>{std::move(names_deque)});
 }
 
 bool ConfigOptions::Contains(const std::string &name) const {
@@ -241,20 +152,17 @@ string ConfigOptions::GetValueAsStringOr(const string &name, string default_valu
     return value_holder ? *value_holder : default_value;
 }
 
+bool ConfigOptions::WriteDefaultConfigOptions(fs::path file_path) const {
+    auto output = ofstream(file_path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << to_string();
+    return true;
+}
+
 string ConfigOptions::to_string() const {
-    auto result = string{"\n"};
-    if (core_value_.is_uninitialized()) {
-        result += "[core]\n<uninitialized>\n";
-    } else {
-        result += format(FMT_STRING("[core]\n{}"), toml::format(core_value_));
-    }
-    result += result.back() != '\n' ? string{"\n"} : string{};
-    if (cli_value_.is_uninitialized()) {
-        result += "[cli]\n<uninitialized>\n";
-    } else {
-        result += format(FMT_STRING("[cli]\n{}"), toml::format(cli_value_));
-    }
-    return result;
+    return toml::format(core_value_, 120u);
 }
 
 } // namespace mmotd::core

--- a/common/src/special_files.cpp
+++ b/common/src/special_files.cpp
@@ -1,11 +1,18 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/assertion/include/assertion.h"
 #include "common/include/logging.h"
 #include "common/include/special_files.h"
 #include "common/include/user_information.h"
 
 #include <filesystem>
+#include <iomanip>
+#include <iterator>
+#include <regex>
+#include <string>
+#include <string_view>
 #include <system_error>
 
+#include <boost/algorithm/string.hpp>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
@@ -17,8 +24,98 @@ using namespace std;
 
 namespace {
 
-fs::path FindProjectRootDirectory() {
 #if defined(DEBUG)
+fs::path FindProjectConfigDirectory() {
+    // Find the '<project root>/config' directory
+    auto project_root = mmotd::core::special_files::FindProjectRootDirectory();
+    if (empty(project_root)) {
+        return fs::path{};
+    }
+    auto ec = error_code{};
+    auto config_dir = project_root / "config" / "";
+    if (auto stat = fs::status(config_dir, ec); ec || !fs::is_directory(stat)) {
+        return fs::path{};
+    }
+    auto config_dir_abs = fs::canonical(config_dir, ec);
+    return ec ? fs::path{} : config_dir_abs;
+}
+#else
+fs::path FindProjectConfigDirectory() {
+    return fs::path{};
+}
+#endif
+
+string StripEnvironmentVariable(string input) {
+    using boost::trim_right_copy_if, boost::trim_left_copy_if, boost::is_any_of;
+    PRECONDITIONS(!empty(input), "unable to strip an environment variable of $ or ${} if its empty");
+    return trim_right_copy_if(trim_left_copy_if(input, is_any_of("${")), is_any_of("}"));
+}
+
+#if defined(__APPLE__) || defined(__linux__)
+vector<fs::path> GetDefaultLocationsUnixCommon() {
+    // $HOME & $XDG_CONFIG_HOME
+    auto default_locations = vector<fs::path>{};
+    auto user_info = mmotd::core::GetUserInformation();
+    auto ec = error_code{};
+    if (empty(user_info.home_directory) || !fs::exists(user_info.home_directory, ec) || ec) {
+        LOG_VERBOSE("home directory either not found or does not exist");
+        return default_locations;
+    }
+    auto home_dir = fs::path(user_info.home_directory);
+    auto dot_config_dir = home_dir / ".config" / "mmotd" / "";
+    if (auto dot_config_dir_abs = fs::weakly_canonical(dot_config_dir, ec); !ec) {
+        default_locations.emplace_back(dot_config_dir_abs);
+    }
+    if (auto home_dir_abs = fs::canonical(home_dir / "", ec); !ec) {
+        default_locations.emplace_back(home_dir_abs);
+    }
+    return default_locations;
+}
+#endif
+
+#if defined(__APPLE__)
+vector<fs::path> GetDefaultLocationsPlatform() {
+    // Need to add $HOME/Library/Application Support/
+    return GetDefaultLocationsUnixCommon();
+}
+#elif defined(__linux__)
+vector<fs::path> GetDefaultLocationsPlatform() {
+    return GetDefaultLocationsUnixCommon();
+}
+#elif defined(_WIN32)
+vector<fs::path> GetDefaultLocationsPlatform() {
+    // Need to add %LocalAppData%
+    return vector<fs::path>{};
+}
+#endif
+
+vector<fs::path> GetDefaultLocationsImpl() {
+    auto default_locations = vector<fs::path>{};
+
+    auto project_config_dir = FindProjectConfigDirectory();
+    if (!empty(project_config_dir)) {
+        default_locations.push_back(project_config_dir);
+    }
+
+    auto platform_default_locations = GetDefaultLocationsPlatform();
+    default_locations.insert(end(default_locations),
+                             begin(platform_default_locations),
+                             end(platform_default_locations));
+
+    return default_locations;
+}
+
+auto IsStdoutTtyImpl() -> bool {
+    auto is_stdout_tty = isatty(STDOUT_FILENO) != 0;
+    LOG_VERBOSE("stdout is{} a TTY", is_stdout_tty ? "" : " not");
+    return is_stdout_tty;
+}
+
+} // namespace
+
+namespace mmotd::core::special_files {
+
+fs::path FindProjectRootDirectory() {
     auto dir_path = fs::current_path();
     auto ec = error_code{};
     auto finished = false;
@@ -44,66 +141,89 @@ fs::path FindProjectRootDirectory() {
         }
     }
     return dir_path;
-#else
-    return fs::path{};
-#endif
 }
 
-// %LocalAppData% -- Windows
-// ~/Library/Application Support/ -- macOS
-// $XDG_CONFIG_HOME -- Linux
-fs::path FindFileImpl(string_view file_name) {
-    auto config_path = fs::path{};
-    auto ec = error_code{};
+string GetEnvironmentValue(string variable_name) {
+    if (empty(variable_name)) {
+        return string{};
+    }
+    auto variable_name_stripped = StripEnvironmentVariable(variable_name);
+    auto *variable_value = getenv(data(variable_name_stripped));
+    return variable_value != nullptr ? string{variable_value} : string{};
+}
 
-    // if running a debug build, try using the in-source version
-    if (auto project_root = FindProjectRootDirectory(); !project_root.empty()) {
-        config_path = project_root / "config" / file_name;
-        LOG_VERBOSE("checking {} for {}", quoted(config_path.parent_path().string()), quoted(file_name));
-        if (fs::exists(config_path, ec) && !ec) {
-            LOG_VERBOSE("found {} in {}", quoted(file_name), quoted(config_path.parent_path().string()));
-            return fs::canonical(config_path);
+string ExpandEnvironmentVariables(string input) {
+    if (empty(input)) {
+        return string{};
+    }
+    static auto env_pattern = std::regex{R"((\$\{[^}]+\})|(\$[\w\d_]+))"};
+    auto envvar_begin = std::sregex_iterator(begin(input), end(input), env_pattern);
+    auto envvar_end = std::sregex_iterator();
+    auto output = string{};
+    auto index = std::smatch::difference_type{0};
+    for (std::sregex_iterator i = envvar_begin; i != envvar_end; ++i) {
+        auto match = *i;
+        if (match.position() > index) {
+            output += input.substr(index, match.position() - index);
+            index = static_cast<std::smatch::difference_type>(match.position() + size(match.str()));
+        }
+
+        // output += match.format("[$&]");
+        output += GetEnvironmentValue(match.str());
+
+        if (std::distance(i, envvar_end) == 1) {
+            output += match.suffix().str();
         }
     }
-
-    auto user_info = mmotd::core::GetUserInformation();
-    if (!empty(user_info.home_directory) && fs::exists(user_info.home_directory, ec) && !ec) {
-        // check for location in various config directories
-        config_path = fs::canonical(fs::path(user_info.home_directory)) / ".config" / "mmotd" / file_name;
-        LOG_VERBOSE("checking {} for {}", quoted(config_path.parent_path().string()), quoted(file_name));
-        if (fs::exists(config_path, ec) && !ec) {
-            LOG_VERBOSE("found {} in {}", quoted(file_name), quoted(config_path.parent_path().string()));
-            return fs::canonical(config_path);
-        }
-        // lastly, check whether it is in the root of the home directory
-        config_path = fs::canonical(fs::path(user_info.home_directory)) / file_name;
-        LOG_VERBOSE("checking {} for {}", quoted(config_path.parent_path().string()), quoted(file_name));
-        if (fs::exists(config_path, ec) && !ec) {
-            LOG_VERBOSE("found {} in {}", quoted(file_name), quoted(config_path.parent_path().string()));
-            return fs::canonical(config_path);
-        }
-    }
-    LOG_VERBOSE("unable to find {} anywhere in the predefined locations", quoted(file_name));
-    return fs::path{};
+    return envvar_begin == envvar_end ? input : output;
 }
-
-auto IsStdoutTtyImpl() -> bool {
-    auto is_stdout_tty = isatty(STDOUT_FILENO) != 0;
-    LOG_VERBOSE("stdout is{} a TTY", is_stdout_tty ? "" : " not");
-    return is_stdout_tty;
-}
-
-} // namespace
-
-namespace mmotd::core::special_files {
 
 auto IsStdoutTty() -> bool {
     static const auto is_stdout_tty = IsStdoutTtyImpl();
     return is_stdout_tty;
 }
 
+vector<fs::path> GetDefaultLocations() {
+    return GetDefaultLocationsImpl();
+}
+
+string GetDefaultLocationsStr() {
+    const auto &default_locations = GetDefaultLocations();
+    auto default_locations_str = string{};
+    for (auto i = begin(default_locations); i != end(default_locations); ++i) {
+        auto dir_path = (*i).string();
+        if (!empty(dir_path) && dir_path.back() != fs::path::preferred_separator) {
+            dir_path.push_back(fs::path::preferred_separator);
+        }
+        auto first = distance(begin(default_locations), i) == 0;
+        auto last = distance(i, end(default_locations)) == 1;
+        auto middle = !first && !last;
+        if (first || (first && last)) {
+            default_locations_str += format(FMT_STRING("{}"), quoted(dir_path));
+        } else if (middle) {
+            default_locations_str += format(FMT_STRING(", {}"), quoted(dir_path));
+        } else if (last) {
+            default_locations_str += format(FMT_STRING(" and {}"), quoted(dir_path));
+        }
+    }
+    return default_locations_str;
+}
+
 fs::path FindFileInDefaultLocations(string_view file_name) {
-    return FindFileImpl(file_name);
+    const auto &default_locations = GetDefaultLocations();
+    for (const auto &dir_path : default_locations) {
+        auto file_path = dir_path / file_name;
+        auto ec = error_code{};
+        if (fs::exists(file_path, ec) && !ec) {
+            if (auto file_path_abs = fs::canonical(file_path, ec); !ec) {
+                LOG_VERBOSE("found {} in {}", quoted(file_name), quoted(dir_path.string()));
+                return file_path_abs;
+            }
+        }
+        LOG_VERBOSE("did NOT find {} in {}", quoted(file_name), quoted(dir_path.string()));
+    }
+    LOG_VERBOSE("did NOT find {} in any default locations", quoted(file_name));
+    return fs::path{};
 }
 
 } // namespace mmotd::core::special_files

--- a/common/test/src/test_algorithm.cpp
+++ b/common/test/src/test_algorithm.cpp
@@ -1,0 +1,108 @@
+#include "common/include/algorithm.h"
+
+#include <stdexcept>
+#include <string_view>
+
+#include <catch2/catch.hpp>
+#include <fmt/format.h>
+
+using namespace Catch;
+using namespace Catch::Matchers;
+using namespace std;
+using namespace mmotd::algorithms;
+
+namespace mmotd::test {
+
+CATCH_TEST_CASE("split_sentence", "[algorithms]") {
+    CATCH_SECTION("split-empty-sentence") {
+        CATCH_CHECK(split_sentence(string{}, 80ull) == string{});
+        CATCH_CHECK(split_sentence(string{}, 0ull) == string{});
+    }
+    CATCH_SECTION("ensure-split-sentence-size") {
+        static const auto sentence = string{"some text here"};
+        CATCH_CHECK(split_sentence(sentence, size(sentence) - 1) == string{"some text\nhere"});
+        CATCH_CHECK(split_sentence(sentence, size(sentence)) == sentence);
+        CATCH_CHECK(split_sentence(sentence, size(sentence) + 1) == sentence);
+    }
+    CATCH_SECTION("large-sentence-split-40") {
+        const auto fixed_input = string{
+            R"(Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc bibendum lacinia orci. Nullam a pretium nulla, sagittis ultrices est. Curabitur ultricies eget dui vel faucibus. Etiam id lacus purus. Suspendisse maximus augue massa, sagittis consectetur felis viverra non. Phasellus ac purus aliquam lacus venenatis aliquet quis tristique sapien. Nam eget rutrum orci. Maecenas viverra odio mi, sit amet cursus magna convallis vitae. Donec lectus justo, iaculis et justo in, consectetur malesuada sem. Nunc consectetur sed massa et sodales. Suspendisse elementum in risus at euismod. Donec posuere tristique lectus, ut vulputate nibh condimentum sed. Morbi ac orci in diam luctus pharetra at nec justo.)"};
+        const auto fixed_output = string{R"(Lorem ipsum dolor sit amet, consectetur
+adipiscing elit. Nunc bibendum lacinia
+orci. Nullam a pretium nulla, sagittis
+ultrices est. Curabitur ultricies eget
+dui vel faucibus. Etiam id lacus purus.
+Suspendisse maximus augue massa,
+sagittis consectetur felis viverra non.
+Phasellus ac purus aliquam lacus
+venenatis aliquet quis tristique
+sapien. Nam eget rutrum orci. Maecenas
+viverra odio mi, sit amet cursus magna
+convallis vitae. Donec lectus justo,
+iaculis et justo in, consectetur
+malesuada sem. Nunc consectetur sed
+massa et sodales. Suspendisse elementum
+in risus at euismod. Donec posuere
+tristique lectus, ut vulputate nibh
+condimentum sed. Morbi ac orci in diam
+luctus pharetra at nec justo.)"};
+        auto output = split_sentence(fixed_input, 40);
+        CATCH_CHECK(output == fixed_output);
+    }
+    CATCH_SECTION("large-sentence-split-80") {
+        const auto fixed_input = string{
+            R"(Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc bibendum lacinia orci. Nullam a pretium nulla, sagittis ultrices est. Curabitur ultricies eget dui vel faucibus. Etiam id lacus purus. Suspendisse maximus augue massa, sagittis consectetur felis viverra non. Phasellus ac purus aliquam lacus venenatis aliquet quis tristique sapien. Nam eget rutrum orci. Maecenas viverra odio mi, sit amet cursus magna convallis vitae. Donec lectus justo, iaculis et justo in, consectetur malesuada sem. Nunc consectetur sed massa et sodales. Suspendisse elementum in risus at euismod. Donec posuere tristique lectus, ut vulputate nibh condimentum sed. Morbi ac orci in diam luctus pharetra at nec justo.)"};
+        const auto fixed_output =
+            string{R"(Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc bibendum lacinia
+orci. Nullam a pretium nulla, sagittis ultrices est. Curabitur ultricies eget
+dui vel faucibus. Etiam id lacus purus. Suspendisse maximus augue massa,
+sagittis consectetur felis viverra non. Phasellus ac purus aliquam lacus
+venenatis aliquet quis tristique sapien. Nam eget rutrum orci. Maecenas viverra
+odio mi, sit amet cursus magna convallis vitae. Donec lectus justo, iaculis et
+justo in, consectetur malesuada sem. Nunc consectetur sed massa et sodales.
+Suspendisse elementum in risus at euismod. Donec posuere tristique lectus, ut
+vulputate nibh condimentum sed. Morbi ac orci in diam luctus pharetra at nec
+justo.)"};
+        auto output = split_sentence(fixed_input, 80);
+        CATCH_CHECK(output == fixed_output);
+    }
+    CATCH_SECTION("large-word-sentence-split") {
+        const auto fixed_input = string{"pneumonoultramicroscopicsilicovolcanoconiosis"};
+        CATCH_CHECK(split_sentence(fixed_input, 30) == fixed_input);
+        CATCH_CHECK(split_sentence(fixed_input, 40) == fixed_input);
+        CATCH_CHECK(split_sentence(fixed_input, 50) == fixed_input);
+    }
+    CATCH_SECTION("large-word-start-sentence-split") {
+        const auto fixed_input = string{
+            R"(Pneumonoultramicroscopicsilicovolcanoconiosis is lung disease caused by the inhalation of silica or quartz dust.)"};
+        const auto fixed_output = string{
+            R"(Pneumonoultramicroscopicsilicovolcanoconiosis
+is lung disease caused by the
+inhalation of silica or quartz dust.)"};
+        auto output = split_sentence(fixed_input, 40);
+        CATCH_CHECK(output == fixed_output);
+    }
+    CATCH_SECTION("large-word-middle-sentence-split") {
+        const auto fixed_input = string{
+            R"(A lung disease known as pneumonoultramicroscopicsilicovolcanoconiosis is caused by the inhalation of silica or quartz dust.)"};
+        const auto fixed_output = string{
+            R"(A lung disease known as
+pneumonoultramicroscopicsilicovolcanoconiosis
+is caused by the inhalation of silica
+or quartz dust.)"};
+        auto output = split_sentence(fixed_input, 40);
+        CATCH_CHECK(output == fixed_output);
+    }
+    CATCH_SECTION("large-word-end-sentence-split") {
+        const auto fixed_input = string{
+            R"(A lung disease caused by the inhalation of silica or quartz dust is called pneumonoultramicroscopicsilicovolcanoconiosis.)"};
+        const auto fixed_output = string{
+            R"(A lung disease caused by the inhalation
+of silica or quartz dust is called
+pneumonoultramicroscopicsilicovolcanoconiosis.)"};
+        auto output = split_sentence(fixed_input, 40);
+        CATCH_CHECK(output == fixed_output);
+    }
+}
+
+} // namespace mmotd::test

--- a/common/test/src/test_special_files.cpp
+++ b/common/test/src/test_special_files.cpp
@@ -1,0 +1,91 @@
+#include "common/include/special_files.h"
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include <boost/algorithm/string.hpp>
+#include <catch2/catch.hpp>
+
+using namespace mmotd::core::special_files;
+using namespace std;
+using namespace std::literals;
+
+namespace mmotd::results::test {
+
+CATCH_TEST_CASE("empty GetEnvironmentValue", "[SpecialFiles]") {
+    CATCH_CHECK(GetEnvironmentValue(string{}) == string{});
+}
+
+CATCH_TEST_CASE("undefined GetEnvironmentValue", "[SpecialFiles]") {
+    CATCH_CHECK(GetEnvironmentValue("NO_WAY_THIS_ENV_VAR_IS_DEFINED"s) == string{});
+}
+
+CATCH_TEST_CASE("empty ExpandEnvironmentVariables", "[SpecialFiles]") {
+    CATCH_CHECK(ExpandEnvironmentVariables(string{}) == string{});
+}
+
+CATCH_TEST_CASE("undefined ExpandEnvironmentVariables", "[SpecialFiles]") {
+    CATCH_SECTION("dollar-curlybrace-variable-curlybrace") {
+        auto expanded = ExpandEnvironmentVariables("this is the ${NO_WAY_THIS_ENV_VAR_IS_DEFINED} string"s);
+        CATCH_CHECK(expanded == "this is the  string"s);
+    }
+    CATCH_SECTION("dollar-variable") {
+        auto expanded = ExpandEnvironmentVariables("this is the $NO_WAY_THIS_ENV_VAR_IS_DEFINED string"s);
+        CATCH_CHECK(expanded == "this is the  string"s);
+    }
+}
+
+CATCH_TEST_CASE("first in string ExpandEnvironmentVariables", "[SpecialFiles]") {
+    CATCH_SECTION("dollar-curlybrace-variable-curlybrace") {
+        CATCH_CHECK(!ExpandEnvironmentVariables("${USER}"s).empty());
+    }
+    CATCH_SECTION("dollar-variable") { CATCH_CHECK(!ExpandEnvironmentVariables("$USER"s).empty()); }
+}
+
+CATCH_TEST_CASE("middle in string ExpandEnvironmentVariables", "[SpecialFiles]") {
+    CATCH_SECTION("dollar-curlybrace-variable-curlybrace") {
+        auto expanded = ExpandEnvironmentVariables("/filling/${USER}/filling/"s);
+        auto trimmed = boost::replace_all_copy(expanded, "/filling/"s, ""s);
+        CATCH_CHECK(!trimmed.empty());
+    }
+    CATCH_SECTION("dollar-variable") {
+        auto expanded = ExpandEnvironmentVariables("/filling/$USER/filling/"s);
+        auto trimmed = boost::replace_all_copy(expanded, "/filling/"s, ""s);
+        CATCH_CHECK(!trimmed.empty());
+    }
+}
+
+CATCH_TEST_CASE("last in string ExpandEnvironmentVariables", "[SpecialFiles]") {
+    CATCH_SECTION("dollar-curlybrace-variable-curlybrace") {
+        auto expanded = ExpandEnvironmentVariables("/filling/${HOME}"s);
+        auto trimmed = expanded.substr("/filling/"s.size());
+        CATCH_CHECK(!trimmed.empty());
+    }
+    CATCH_SECTION("dollar-variable") {
+        auto expanded = ExpandEnvironmentVariables("/filling/$HOME"s);
+        auto trimmed = expanded.substr("/filling/"s.size());
+        CATCH_CHECK(!trimmed.empty());
+    }
+}
+
+CATCH_TEST_CASE("multiple in string ExpandEnvironmentVariables", "[SpecialFiles]") {
+    CATCH_SECTION("dollar-curlybrace-variable-curlybrace") {
+        auto expanded = ExpandEnvironmentVariables("${USER}/filling/${HOME}"s);
+        auto trimmed = boost::replace_all_copy(expanded, "/filling/"s, ""s);
+        CATCH_CHECK(!trimmed.empty());
+    }
+    CATCH_SECTION("dollar-variable") {
+        auto expanded = ExpandEnvironmentVariables("$USER/filling/$HOME"s);
+        auto trimmed = boost::replace_all_copy(expanded, "/filling/"s, ""s);
+        CATCH_CHECK(!trimmed.empty());
+    }
+}
+
+CATCH_TEST_CASE("no variables ExpandEnvironmentVariables", "[SpecialFiles]") {
+    auto expanded = ExpandEnvironmentVariables("/a/b/data/dir.txt"s);
+    CATCH_CHECK(expanded == "/a/b/data/dir.txt"s);
+}
+
+} // namespace mmotd::results::test

--- a/config/mmotd_config.toml
+++ b/config/mmotd_config.toml
@@ -1,53 +1,20 @@
+#
 # modified message of the day
+#
 
-template_path="/tmp/mmotd_template.json"
+# Enabling this may cause a performance cost. Every write to the log file will be flushed
+#  when set to 'true'. This disables the natural file output caching of log file writes and
+#  may enable seeing more debug statements before a crash.
+logging_flush=false
 
-[information-providers]
+# Replace the following with the location of where your "mmotd_template.json" exists
+# template_path="$HOME/.config/mmotd/mmotd_template.json"
 
-# display last login
-last-login=false
+# This is the same value that is the last couple of segments of the file linked to /etc/localtime
+# /var/db/timezone/zoneinfo/America/Denver
+timezone="America/Denver"
 
-# display computer name
-computer-name=false
-
-# display host name
-host-name=false
-
-# display public ip address
-public-ip=false
-
-# display unread mail
-unread-mail=false
-
-# display system load
-system-load=false
-
-# display processor count
-processor-count=false
-
-# display disk usage
-disk-usage=false
-
-# display users logged in count
-users-count=false
-
-# display memory usage
-memory-usage=false
-
-# display swap usage
-swap-usage=false
-
-# display active network interfaces (ip and mac address)
-active-network-interfaces=false
-
-# display greeting using user name, OS name, release and kernel
-greeting=false
-
-# display the system information header with date and time
-header=false
-
-# display the system information sub-header with location, weather, sunrise and sunset
-sub-header=false
-
-# display a random quote
-random-quote=false
+# The following three values are used to look-up the local whether, http://wttr.in/Albuquerque%20NM%20USA
+city="Albuquerque"
+state="NM"
+country="USA"

--- a/lib/src/memory.cpp
+++ b/lib/src/memory.cpp
@@ -7,7 +7,6 @@
 #include "lib/include/platform/memory.h"
 
 #include <fmt/format.h>
-#include <scope_guard.hpp>
 
 using fmt::format;
 using namespace std;

--- a/lib/src/platform/darwin/swap.cpp
+++ b/lib/src/platform/darwin/swap.cpp
@@ -9,7 +9,6 @@
 #include <unordered_map>
 
 #include <fmt/format.h>
-#include <scope_guard.hpp>
 
 #include <sys/sysctl.h>
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,12 +13,14 @@ set_default_policies()
 
 add_executable(${MMOTD_TARGET_NAME}
                ../common/test/src/exception_matcher.cpp
+               ../common/test/src/test_algorithm.cpp
                ../common/test/src/test_assertion.cpp
                ../common/test/src/test_config_options.cpp
                ../common/test/src/test_exception.cpp
                ../common/test/src/test_mac_address.cpp
-               ../common/test/src/test_position_index.cpp
                ../common/test/src/test_output_template.cpp
+               ../common/test/src/test_position_index.cpp
+               ../common/test/src/test_special_files.cpp
                ../common/test/src/test_template_string.cpp
                ../lib/test/src/test_information_definitions.cpp
                src/main.cpp


### PR DESCRIPTION
Closing #53 and #54 
Add: config options for `timezone`, `city`, `state`, `country`.
Refactor: making the default config options work in all cases.
Refactor: help message to point out where the app will look for config
          and template files.
Add: ability to use environment variables within paths for the config
     and template files.
Add: unit tests to ensure that the default config and template files
     always match the built-in versions of these files.
Bump: versions of the various dependencies specified within
      `cmake/find_dependencies.cmake`.
Fix: An issue where using `boost::asio` and `clang++-13` triggers a
compiler error:
```
boost/asio/detail/type_traits.hpp:89:12: error: no
member named 'result_of' in namespace 'std'
using std::result_of;
      ~~~~~^
```
To fix this issue was to define the following in the project:
`BOOST_ASIO_HAS_STD_INVOKE_RESULT`