### PR TITLE
Change custom endian enum to std::endian

### DIFF
--- a/lib/include/platform/hardware_information.h
+++ b/lib/include/platform/hardware_information.h
@@ -1,28 +1,25 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #pragma once
 
+#include "lib/include/platform/hardware_temperature.h"
+
+#include <bit>
 #include <cstdint>
 #include <iterator>
 #include <string>
-#include "lib/include/platform/hardware_temperature.h"
+#include <optional>
 
 namespace mmotd::platform {
 
-enum class EndianType {
-    little,
-    big,
-    unknown,
-};
-
-std::string to_string(EndianType endian);
-EndianType from_endian_string(std::string endian_str);
+std::string to_string(std::endian endian_value);
+std::optional<std::endian> from_endian_string(std::string endian_str);
 
 struct HardwareDetails {
     std::string machine_type;
     std::string machine_model;
     std::int32_t cpu_core_count = 0;
     std::string cpu_name;
-    EndianType byte_order = EndianType::unknown;
+    std::optional<std::endian> byte_order;
     Temperature cpu_temperature;
     std::string gpu_name;
     Temperature gpu_temperature;

--- a/lib/src/hardware_information.cpp
+++ b/lib/src/hardware_information.cpp
@@ -4,14 +4,15 @@
 #include "lib/include/platform/hardware_information.h"
 #include "lib/include/platform/hardware_temperature.h"
 
+#include <bit>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <tuple>
 #include <vector>
 
 using namespace std;
 using namespace std::literals;
-using mmotd::platform::EndianType;
 
 bool gLinkHardwareInformation = false;
 
@@ -28,47 +29,48 @@ void HardwareInformation::FindInformation() {
 }
 
 void HardwareInformation::CreateInformationObjects(const mmotd::platform::HardwareDetails &details) {
+    const auto UNKNOWN_STR = GetUnknownProperty();
+
     auto machine_type = GetInfoTemplate(InformationId::ID_HARDWARE_MACHINE_TYPE);
-    machine_type.SetValueArgs(details.machine_type);
+    machine_type.SetValueArgs(std::empty(details.machine_type) ? UNKNOWN_STR : details.machine_type);
     AddInformation(machine_type);
 
     auto machine_model = GetInfoTemplate(InformationId::ID_HARDWARE_MACHINE_MODEL);
-    machine_model.SetValueArgs(details.machine_model);
+    machine_model.SetValueArgs(std::empty(details.machine_model) ? UNKNOWN_STR : details.machine_model);
     AddInformation(machine_model);
 
     auto cpu_core_count = GetInfoTemplate(InformationId::ID_HARDWARE_CPU_CORE_COUNT);
-    cpu_core_count.SetValueArgs(details.cpu_core_count);
+    cpu_core_count.SetValueArgs(details.cpu_core_count == 0 ? UNKNOWN_STR : std::to_string(details.cpu_core_count));
     AddInformation(cpu_core_count);
 
     auto cpu_name = GetInfoTemplate(InformationId::ID_HARDWARE_CPU_NAME);
-    cpu_name.SetValueArgs(details.cpu_name);
+    cpu_name.SetValueArgs(std::empty(details.cpu_name) ? UNKNOWN_STR : details.cpu_name);
     AddInformation(cpu_name);
 
     auto byte_order = GetInfoTemplate(InformationId::ID_HARDWARE_CPU_BYTE_ORDER);
-    byte_order.SetValueArgs(to_string(details.byte_order));
+    byte_order.SetValueArgs(details.byte_order.has_value() ? mmotd::platform::to_string(*details.byte_order) :
+                                                             UNKNOWN_STR);
     AddInformation(byte_order);
 
-    static constexpr auto UNKNOWN_DATA = "[unknown]"sv;
-
     auto gpu_name = GetInfoTemplate(InformationId::ID_HARDWARE_GPU_MODEL_NAME);
-    gpu_name.SetValueArgs(empty(details.gpu_name) ? UNKNOWN_DATA : details.gpu_name);
+    gpu_name.SetValueArgs(empty(details.gpu_name) ? UNKNOWN_STR : details.gpu_name);
     AddInformation(gpu_name);
 
     auto monitor_name = GetInfoTemplate(InformationId::ID_HARDWARE_MONITOR_NAME);
-    monitor_name.SetValueArgs(empty(details.monitor_name) ? UNKNOWN_DATA : details.monitor_name);
+    monitor_name.SetValueArgs(empty(details.monitor_name) ? UNKNOWN_STR : details.monitor_name);
     AddInformation(monitor_name);
 
     auto monitor_resolution = GetInfoTemplate(InformationId::ID_HARDWARE_MONITOR_RESOLUTION);
-    monitor_resolution.SetValueArgs(empty(details.monitor_resolution) ? UNKNOWN_DATA : details.monitor_resolution);
+    monitor_resolution.SetValueArgs(empty(details.monitor_resolution) ? UNKNOWN_STR : details.monitor_resolution);
     AddInformation(monitor_resolution);
 
     auto cpu_temperature = GetInfoTemplate(InformationId::ID_HARDWARE_CPU_TEMPERATURE);
-    cpu_temperature.SetValueArgs(std::empty(details.cpu_temperature) ? UNKNOWN_DATA :
+    cpu_temperature.SetValueArgs(std::empty(details.cpu_temperature) ? UNKNOWN_STR :
                                                                        details.cpu_temperature.to_string());
     AddInformation(cpu_temperature);
 
     auto gpu_temperature = GetInfoTemplate(InformationId::ID_HARDWARE_GPU_TEMPERATURE);
-    gpu_temperature.SetValueArgs(std::empty(details.gpu_temperature) ? UNKNOWN_DATA :
+    gpu_temperature.SetValueArgs(std::empty(details.gpu_temperature) ? UNKNOWN_STR :
                                                                        details.gpu_temperature.to_string());
     AddInformation(gpu_temperature);
 }

--- a/lib/src/platform/darwin/hardware_information.cpp
+++ b/lib/src/platform/darwin/hardware_information.cpp
@@ -8,6 +8,7 @@
 #include "lib/include/system_details.h"
 
 #include <array>
+#include <bit>
 #include <cstddef>
 #include <iterator>
 #include <string_view>
@@ -240,24 +241,22 @@ optional<int32_t> GetCpuCount() {
     }
 }
 
-mmotd::platform::EndianType GetByteOrder() {
-    using mmotd::platform::EndianType;
+optional<endian> GetByteOrder() {
     uint32_t byte_order = 0;
     auto buffer_size = size_t{4};
     if (sysctlbyname("hw.byteorder", &byte_order, &buffer_size, nullptr, 0) == -1) {
         auto error_str = mmotd::error::posix_error::to_string();
         LOG_ERROR("error calling sysctlbyname with hw.byteorder, details: {}", error_str);
-        return mmotd::platform::EndianType::unknown;
+        return nullopt;
     }
-    static constexpr uint32_t BIG_ENDIAN_REPR = 4321;
-    static constexpr uint32_t LITTLE_ENDIAN_REPR = 1234;
+    static constexpr uint32_t BIG_ENDIAN_REPR = 4321u;
+    static constexpr uint32_t LITTLE_ENDIAN_REPR = 1234u;
     if (byte_order == BIG_ENDIAN_REPR) {
-        return EndianType::big;
+        return endian::big;
     } else if (byte_order == LITTLE_ENDIAN_REPR) {
-        return EndianType::little;
-    } else {
-        return EndianType::unknown;
+        return endian::little;
     }
+    return nullopt;
 }
 
 string GetCpuName() {

--- a/lib/src/platform/hardware_information.cpp
+++ b/lib/src/platform/hardware_information.cpp
@@ -1,6 +1,8 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "lib/include/platform/hardware_information.h"
 
+#include <bit>
+#include <optional>
 #include <string>
 
 #include <boost/algorithm/string.hpp>
@@ -9,34 +11,33 @@ using namespace std;
 
 namespace mmotd::platform {
 
-string to_string(EndianType endian) {
+string to_string(endian endian_value) {
     using namespace std::literals;
-    switch (endian) {
-        case EndianType::little:
-            return "little endian"s;
-        case EndianType::big:
-            return "big endian"s;
-        case EndianType::unknown:
-        default:
-            return "unknown"s;
+    if (endian_value == endian::big) {
+        return "big-endian"s;
+    } else if (endian_value == endian::little) {
+        return "little-endian"s;
+    } else if (endian_value != endian::big && endian_value != endian::little) {
+        return "mixed-endian"s;
+    } else {
+        return "unknown-endian"s;
     }
 }
 
-EndianType from_endian_string(string endian_str) {
+optional<endian> from_endian_string(string endian_str) {
     using namespace boost::algorithm;
-    if (icontains(endian_str, "little")) {
-        return EndianType::little;
-    } else if (icontains(endian_str, "big")) {
-        return EndianType::big;
+    if (icontains(endian_str, "big")) {
+        return endian::big;
+    } else if (icontains(endian_str, "little")) {
+        return endian::little;
     } else {
-        return EndianType::unknown;
+        return std::nullopt;
     }
 }
 
 bool HardwareDetails::empty() const noexcept {
     return std::empty(machine_type) && std::empty(machine_model) && cpu_core_count == 0 && std::empty(cpu_name) &&
-           byte_order == EndianType::unknown && std::empty(gpu_name) && std::empty(monitor_name) &&
-           std::empty(monitor_resolution);
+           !byte_order && std::empty(gpu_name) && std::empty(monitor_name) && std::empty(monitor_resolution);
 }
 
 } // namespace mmotd::platform

--- a/lib/src/platform/linux/hardware_information.cpp
+++ b/lib/src/platform/linux/hardware_information.cpp
@@ -7,6 +7,7 @@
 #include "lib/include/hardware_information.h"
 #include "lib/include/platform/hardware_information.h"
 
+#include <bit>
 #include <charconv>
 #include <filesystem>
 #include <fstream>
@@ -25,7 +26,6 @@ namespace fs = std::filesystem;
 using fmt::format;
 using namespace std;
 using json = nlohmann::json;
-using mmotd::platform::EndianType, mmotd::platform::from_endian_string;
 
 namespace {
 
@@ -59,10 +59,12 @@ void from_json(const json &root, LscpuContainer &lscpu_ontainer) {
     root.at("lscpu").get_to(lscpu_ontainer.name_values);
 }
 
-tuple<string, int32_t, EndianType> ParseLscpuOutput(optional<string> output_holder) {
+using CpuInfo = tuple<string, int32_t, optional<endian>>;
+
+CpuInfo ParseLscpuOutput(optional<string> output_holder) {
     // ensure input is valid
     if (!output_holder) {
-        return tuple<string, int32_t, EndianType>{};
+        return CpuInfo{};
     }
     auto output = *output_holder;
 
@@ -70,7 +72,7 @@ tuple<string, int32_t, EndianType> ParseLscpuOutput(optional<string> output_hold
     auto root = json::parse(output, nullptr, false, true);
     if (root.is_null()) {
         LOG_ERROR("parsing output of 'lscpu' into json, output: '{}'", output);
-        return tuple<string, int32_t, EndianType>{};
+        return CpuInfo{};
     }
 
     // serialize the nlohmann::json data to an actual data structure
@@ -78,10 +80,15 @@ tuple<string, int32_t, EndianType> ParseLscpuOutput(optional<string> output_hold
     from_json(root, lscpu);
 
     // query the data structure for byte order
-    auto byte_order_holder = lscpu.GetData("Byte Order:");
-    auto byte_order = EndianType::unknown;
-    if (byte_order_holder) {
-        byte_order = from_endian_string(*byte_order_holder);
+    auto byte_order = optional<endian>{};
+    if (auto byte_order_str_holder = lscpu.GetData("Byte Order:"); !byte_order_str_holder) {
+        LOG_ERROR("lscpu output does not contain 'Byte Order:');
+    } else {
+        if (auto byte_order_holder = from_endian_string(*byte_order_str_holder); !byte_order_holder) {
+            LOG_ERROR("unable to parse '{}' as endian", *byte_order_str_holder);
+        } else {
+            byte_order = byte_order_holder;
+        }
     }
 
     // query the data structure for cpu count
@@ -100,12 +107,11 @@ tuple<string, int32_t, EndianType> ParseLscpuOutput(optional<string> output_hold
     auto cpu_name_holder = lscpu.GetData("Model name:");
     auto cpu_name = cpu_name_holder.value_or(string{});
 
-    return make_tuple(cpu_name, cpu_count, byte_order);
+    return make_tuple(cpu_name, cpu_count, {byte_order});
 }
 
-tuple<string, int32_t, EndianType> GetCpuInformation() {
+CpuInfo GetCpuInformation() {
     using mmotd::system::command::Run;
-
     return Run("/usr/bin/lscpu", {"--json"}, ParseLscpuOutput);
 }
 

--- a/lib/src/platform/linux/hardware_information.cpp
+++ b/lib/src/platform/linux/hardware_information.cpp
@@ -1,10 +1,11 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #if defined(__linux__)
+#include "lib/include/hardware_information.h"
+
 #include "common/include/iostream_error.h"
 #include "common/include/logging.h"
 #include "common/include/posix_error.h"
 #include "common/include/system_command.h"
-#include "lib/include/hardware_information.h"
 #include "lib/include/platform/hardware_information.h"
 
 #include <bit>
@@ -62,6 +63,7 @@ void from_json(const json &root, LscpuContainer &lscpu_ontainer) {
 using CpuInfo = tuple<string, int32_t, optional<endian>>;
 
 CpuInfo ParseLscpuOutput(optional<string> output_holder) {
+    using mmotd::platform::from_endian_string;
     // ensure input is valid
     if (!output_holder) {
         return CpuInfo{};
@@ -82,7 +84,7 @@ CpuInfo ParseLscpuOutput(optional<string> output_holder) {
     // query the data structure for byte order
     auto byte_order = optional<endian>{};
     if (auto byte_order_str_holder = lscpu.GetData("Byte Order:"); !byte_order_str_holder) {
-        LOG_ERROR("lscpu output does not contain 'Byte Order:');
+        LOG_ERROR("lscpu output does not contain 'Byte Order:'");
     } else {
         if (auto byte_order_holder = from_endian_string(*byte_order_str_holder); !byte_order_holder) {
             LOG_ERROR("unable to parse '{}' as endian", *byte_order_str_holder);
@@ -107,7 +109,7 @@ CpuInfo ParseLscpuOutput(optional<string> output_holder) {
     auto cpu_name_holder = lscpu.GetData("Model name:");
     auto cpu_name = cpu_name_holder.value_or(string{});
 
-    return make_tuple(cpu_name, cpu_count, {byte_order});
+    return make_tuple(cpu_name, cpu_count, byte_order);
 }
 
 CpuInfo GetCpuInformation() {


### PR DESCRIPTION
In the few places where the code was referencing the `endian`-ness of the system, change that `enum class EndianType` to use `std::endian` instead.