### PR TITLE
Re-enable conversion & cast warnings

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -77,6 +77,9 @@ IncludeCategories:
   # C++ system headers (as of C++17).
   - Regex:    '^[<"](algorithm|any|array|atomic|bit|bitset|cassert|ccomplex|cctype|cerrno|cfenv|cfloat|charconv|chrono|cinttypes|ciso646|climits|clocale|cmath|codecvt|complex|condition_variable|csetjmp|csignal|cstdalign|cstdarg|cstdbool|cstddef|cstdint|cstdio|cstdlib|cstring|ctgmath|ctime|cuchar|cwchar|cwctype|deque|exception|execution|filesystem|forward_list|fstream|functional|future|initializer_list|iomanip|ios|iosfwd|iostream|istream|iterator|limits|list|locale|map|memory|memory_resource|mutex|new|numeric|optional|ostream|queue|random|ratio|regex|scoped_allocator|set|shared_mutex|sstream|stack|stdexcept|streambuf|string|string_view|strstream|system_error|thread|tuple|type_traits|typeindex|typeinfo|unordered_map|unordered_set|utility|valarray|variant|vector|version)[">]$'
     Priority: 20
+  # C++ system header folders (as of C++17).
+  - Regex:    '^[<"]experimental/'
+    Priority: 20
   # Boost headers
   - Regex:    '^[<"]boost/'
     Priority: 30

--- a/cmake/target_common.cmake
+++ b/cmake/target_common.cmake
@@ -166,11 +166,9 @@ macro (setup_target_properties MMOTD_TARTET_NAME PROJECT_ROOT_INCLUDE_PATH)
         # warn if you overload (not override) a virtual function
         PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-Woverloaded-virtual>
         # warn on type conversions that may lose data
-        # TODO: fix_jasoni... re-enable
-        PRIVATE $<$<AND:$<BOOL:FALSE>,$<CXX_COMPILER_ID:AppleClang,Clang,GNU>>:-Wconversion>
+        PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-Wconversion>
         # warn on sign conversions
-        # TODO: fix_jasoni... re-enable
-        PRIVATE $<$<AND:$<BOOL:FALSE>,$<CXX_COMPILER_ID:AppleClang,Clang,GNU>>:-Wsign-conversion>
+        PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-Wsign-conversion>
         # warn if float is implicit promoted to double
         PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-Wdouble-promotion>
         # warn on security issues around functions that format output (ie `printf`)
@@ -204,10 +202,8 @@ macro (setup_target_properties MMOTD_TARTET_NAME PROJECT_ROOT_INCLUDE_PATH)
         # warn if a null dereference is detected
         PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wnull-dereference>
         # warn if you perform a cast to the same type
-        # TODO: fix_jasoni... re-enable
-        PRIVATE $<$<AND:$<BOOL:FALSE>,$<CXX_COMPILER_ID:GNU>>:-Wuseless-cast>
-        # TODO: fix_jasoni... re-enable
-        PRIVATE $<$<AND:$<BOOL:FALSE>,$<CXX_COMPILER_ID:AppleClang,Clang,GNU>>:-Wcast-qual>
+        PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wuseless-cast>
+        PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-Wcast-qual>
 
         # disable -- clang
         PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Wno-gnu-zero-variadic-macro-arguments>
@@ -266,7 +262,6 @@ macro (setup_target_properties MMOTD_TARTET_NAME PROJECT_ROOT_INCLUDE_PATH)
         ${MMOTD_TARGET_NAME} SYSTEM
         PRIVATE ${BACKWARD_INCLUDE_DIRS}
         PRIVATE ${Boost_INCLUDE_DIRS}
-        # PRIVATE ${certify_SOURCE_DIR}/include
         PRIVATE ${CURL_INCLUDE_DIR}
         PRIVATE ${spdlog_SOURCE_DIR}/include
         PRIVATE ${cli11_SOURCE_DIR}/include

--- a/common/include/chrono_io.h
+++ b/common/include/chrono_io.h
@@ -94,7 +94,7 @@ inline auto time_from_string(std::string_view input, const char *chrono_format) 
     return time_from_string(std::string(input), chrono_format);
 }
 
-inline std::optional<std::size_t> get_current_hour() {
+inline std::optional<std::chrono::hours::rep> get_current_hour() {
     auto now_time_point = date::make_zoned(GetTimeZone(), std::chrono::system_clock::now());
     auto hour_str = date::format("%H", now_time_point);
     const auto &loc = std::locale();
@@ -110,16 +110,16 @@ inline std::optional<std::size_t> get_current_hour() {
         if (hour > 23) {
             hour = std::size_t{23};
         }
-        return {hour};
+        return std::make_optional(static_cast<std::chrono::hours::rep>(hour));
     }
 }
 
 } // namespace detail
 
 using detail::date_time_from_string;
-using detail::time_from_string;
 using detail::get_current_hour;
 using detail::GetTimeZone;
+using detail::time_from_string;
 using detail::to_string;
 
 } // namespace mmotd::chrono::io

--- a/common/src/output_template_writer.cpp
+++ b/common/src/output_template_writer.cpp
@@ -45,7 +45,8 @@ inline size_t GetUtf8DisplayLength(string input) {
         LOG_ERROR("invalid utf8: {}, at offset: {}", input, i);
         input = utf8::replace_invalid(input);
     }
-    return utf8::distance(input.begin(), input.end());
+    auto utf8_length = utf8::distance(input.begin(), input.end());
+    return static_cast<size_t>(utf8_length);
 }
 
 struct ColorSpecification {
@@ -545,9 +546,10 @@ size_t OutputRows::GetColumnCount(int column) const noexcept {
     if (column == output_template::ENTIRE_LINE) {
         column_count = size_t{1};
     } else {
-        column_count = count_if(begin(column_indexes), end(column_indexes), [](int index) {
+        auto entire_line_count = count_if(begin(column_indexes), end(column_indexes), [](int index) {
             return index != output_template::ENTIRE_LINE;
         });
+        column_count = static_cast<size_t>(entire_line_count);
     }
     return column_count;
 }

--- a/common/src/special_files.cpp
+++ b/common/src/special_files.cpp
@@ -1,7 +1,8 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/special_files.h"
+
 #include "common/assertion/include/assertion.h"
 #include "common/include/logging.h"
-#include "common/include/special_files.h"
 #include "common/include/user_information.h"
 
 #include <filesystem>
@@ -160,12 +161,13 @@ string ExpandEnvironmentVariables(string input) {
     auto envvar_begin = std::sregex_iterator(begin(input), end(input), env_pattern);
     auto envvar_end = std::sregex_iterator();
     auto output = string{};
-    auto index = std::smatch::difference_type{0};
+    auto index = size_t{0};
     for (std::sregex_iterator i = envvar_begin; i != envvar_end; ++i) {
         auto match = *i;
-        if (match.position() > index) {
-            output += input.substr(index, match.position() - index);
-            index = static_cast<std::smatch::difference_type>(match.position() + size(match.str()));
+        auto offset = static_cast<size_t>(match.position());
+        if (offset > index) {
+            output += input.substr(index, offset - index);
+            index = offset + size(match.str());
         }
 
         output += GetEnvironmentValue(match.str());

--- a/common/src/template_column_items.cpp
+++ b/common/src/template_column_items.cpp
@@ -1,9 +1,10 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "common/include/template_column_items.h"
+
 #include "common/assertion/include/assertion.h"
 #include "common/assertion/include/precondition.h"
 #include "common/include/algorithm.h"
 #include "common/include/logging.h"
-#include "common/include/template_column_items.h"
 
 #include <algorithm>
 #include <array>
@@ -441,7 +442,7 @@ string to_string(fmt::text_style txt_style) {
             terminal_color += "strikethrough_";
         }
     }
-    auto terminal_value = static_cast<uint8_t>(txt_style.get_foreground().value.term_color);
+    auto terminal_value = txt_style.get_foreground().value.term_color;
     if (terminal_value >= static_cast<uint8_t>(fmt::terminal_color::bright_black)) {
         terminal_color += "bright_";
     }

--- a/common/test/src/test_algorithm.cpp
+++ b/common/test/src/test_algorithm.cpp
@@ -1,5 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #include "common/include/algorithm.h"
+#include "common/include/human_size.h"
 
 #include <stdexcept>
 #include <string_view>
@@ -103,6 +104,48 @@ of silica or quartz dust is called
 pneumonoultramicroscopicsilicovolcanoconiosis.)"};
         auto output = split_sentence(fixed_input, 40);
         CATCH_CHECK(output == fixed_output);
+    }
+}
+
+CATCH_TEST_CASE("to_human_size", "[algorithms]") {
+    using mmotd::algorithm::string::to_human_size;
+
+    CATCH_SECTION("integers") {
+        CATCH_CHECK(to_human_size(0) == "0.00 B");
+        CATCH_CHECK(to_human_size(1) == "1.00 B");
+        CATCH_CHECK(to_human_size(10) == "10.00 B");
+        CATCH_CHECK(to_human_size(100) == "100.00 B");
+        CATCH_CHECK(to_human_size(1000) == "1000.00 B");
+        CATCH_CHECK(to_human_size(1024) == "1.00 KB");
+        CATCH_CHECK(to_human_size(1000000) == "976.56 KB");
+        CATCH_CHECK(to_human_size(1024 * 1024) == "1.00 MB");
+        CATCH_CHECK(to_human_size(1000000000) == "953.67 MB");
+        CATCH_CHECK(to_human_size(1024ull * 1024ull * 1024ull) == "1.00 GB");
+        CATCH_CHECK(to_human_size(1000000000000ull) == "931.32 GB");
+        CATCH_CHECK(to_human_size(1024ull * 1024ull * 1024ull * 1024ull) == "1.00 TB");
+        CATCH_CHECK(to_human_size(1000000000000000ull) == "909.49 TB");
+        CATCH_CHECK(to_human_size(1024ull * 1024ull * 1024ull * 1024ull * 1024ull) == "1.00 PB");
+        CATCH_CHECK(to_human_size(1000000000000000000ull) == "888.18 PB");
+        CATCH_CHECK(to_human_size(1024ull * 1024ull * 1024ull * 1024ull * 1024ull * 1024ull) == "1.00 EB");
+    }
+
+    CATCH_SECTION("floating-point") {
+        CATCH_CHECK(to_human_size(0.0) == "0.00 B");
+        CATCH_CHECK(to_human_size(1.0) == "1.00 B");
+        CATCH_CHECK(to_human_size(10.0) == "10.00 B");
+        CATCH_CHECK(to_human_size(100.0) == "100.00 B");
+        CATCH_CHECK(to_human_size(1000.0) == "1000.00 B");
+        CATCH_CHECK(to_human_size(1024.0) == "1.00 KB");
+        CATCH_CHECK(to_human_size(1000000.0) == "976.56 KB");
+        CATCH_CHECK(to_human_size(1024.0 * 1024.0) == "1.00 MB");
+        CATCH_CHECK(to_human_size(1000000000.0) == "953.67 MB");
+        CATCH_CHECK(to_human_size(1024.0 * 1024.0 * 1024.0) == "1.00 GB");
+        CATCH_CHECK(to_human_size(1000000000000.0) == "931.32 GB");
+        CATCH_CHECK(to_human_size(1024.0 * 1024.0 * 1024.0 * 1024.0) == "1.00 TB");
+        CATCH_CHECK(to_human_size(1000000000000000.0) == "909.49 TB");
+        CATCH_CHECK(to_human_size(1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0) == "1.00 PB");
+        CATCH_CHECK(to_human_size(1000000000000000000.0) == "888.18 PB");
+        CATCH_CHECK(to_human_size(1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0) == "1.00 EB");
     }
 }
 

--- a/lib/src/fortune.cpp
+++ b/lib/src/fortune.cpp
@@ -1,11 +1,12 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "lib/include/fortune.h"
+
 #include "common/include/algorithm.h"
 #include "common/include/config_options.h"
 #include "common/include/iostream_error.h"
 #include "common/include/logging.h"
 #include "common/include/special_files.h"
 #include "lib/include/computer_information.h"
-#include "lib/include/fortune.h"
 
 #include <array>
 #include <bit>
@@ -54,6 +55,8 @@ string_view GetPlatformFortunesPath() {
     return "/usr/local/opt/fortune/share/games/fortunes";
 }
 
+#define FORTUNE_FILE_BYTESWAP(x) ntohll(x)
+
 #elif defined(__linux__)
 
 static constexpr uint32_t STRFILE_VERSION = 2;
@@ -64,6 +67,8 @@ static constexpr bool STRFILE_ENTRY_CONTAINS_NULL_INT = false;
 string_view GetPlatformFortunesPath() {
     return "/usr/share/games/fortunes";
 }
+
+#define FORTUNE_FILE_BYTESWAP(x) ntohl(x)
 
 #endif
 
@@ -124,11 +129,11 @@ struct StrFileHeader {
     }
 
     void update() {
-        version = ntohl(version);
-        count = ntohl(count);
-        longest_str = ntohl(longest_str);
-        shortest_str = ntohl(shortest_str);
-        flags = static_cast<Flags>(ntohl(static_cast<StrFileIntType>(flags)));
+        version = FORTUNE_FILE_BYTESWAP(version);
+        count = FORTUNE_FILE_BYTESWAP(count);
+        longest_str = FORTUNE_FILE_BYTESWAP(longest_str);
+        shortest_str = FORTUNE_FILE_BYTESWAP(shortest_str);
+        flags = static_cast<Flags>(FORTUNE_FILE_BYTESWAP(static_cast<StrFileIntType>(flags)));
         LOG_VERBOSE("STRFILE: {}", to_string());
     }
 };

--- a/lib/src/general.cpp
+++ b/lib/src/general.cpp
@@ -1,4 +1,6 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
+#include "lib/include/general.h"
+
 #include "common/assertion/include/assertion.h"
 #include "common/include/algorithm.h"
 #include "common/include/chrono_io.h"
@@ -6,7 +8,6 @@
 #include "common/include/logging.h"
 #include "common/include/user_information.h"
 #include "lib/include/computer_information.h"
-#include "lib/include/general.h"
 
 #include <chrono>
 #include <iterator>
@@ -34,7 +35,10 @@ public:
     Greeting() = default;
 
     Greeting(string_view greet_str, HourType begin_hour, HourType end_hour, initializer_list<string_view> emojis) :
-        greeting_str_(greet_str), begin_hour_(begin_hour), end_hour_(end_hour), emojis_(emojis) {}
+        greeting_str_(greet_str),
+        begin_hour_(begin_hour),
+        end_hour_(end_hour),
+        emojis_(emojis) {}
 
     auto begin() const { return begin_hour_; }
     auto end() const { return end_hour_; }
@@ -62,8 +66,7 @@ public:
     string GetLocalDateTime() const;
 
 private:
-    static constexpr auto MORNING_EMOJIS =
-        {"🌤"sv, "⛅"sv, "🌦️"sv, "🌤️"sv, "🌥️"sv, "🌈"sv, "🌦"sv};
+    static constexpr auto MORNING_EMOJIS = {"🌤"sv, "⛅"sv, "🌦️"sv, "🌤️"sv, "🌥️"sv, "🌈"sv, "🌦"sv};
     static constexpr auto AFTERNOON_EMOJIS = {"🌎"sv, "🌎"sv, "🌍"sv, "🌏"sv, "⛱"sv, "🏖"sv};
     static constexpr auto EVENING_EMOJIS =
         {"🌙"sv, "🌖"sv, "🌕"sv, "🌓"sv, "🌛"sv, "🌝"sv, "🌗"sv, "🌜"sv, "🌑"sv, "🌚"sv, "🌘"sv, "🌒"sv, "🌔"sv};

--- a/lib/src/platform/darwin/hardware_information.cpp
+++ b/lib/src/platform/darwin/hardware_information.cpp
@@ -148,9 +148,8 @@ optional<GpuInformation> GpuInformation::QueryGpuInformation() {
         auto graphics_model = GetJsonStringFromPointer(root, graphics_model_query);
         gpu_information.AddGraphicsModelName(graphics_model.value_or(string{}));
 
-        auto index = static_cast<json::difference_type>(i);
-        auto displays_drivers_iter = displays_data_root[index].find("spdisplays_ndrvs");
-        if (displays_drivers_iter == std::end(displays_data_root[index]) || !displays_drivers_iter->is_array()) {
+        auto displays_drivers_iter = displays_data_root[i].find("spdisplays_ndrvs");
+        if (displays_drivers_iter == std::end(displays_data_root[i]) || !displays_drivers_iter->is_array()) {
             continue;
         }
 
@@ -269,7 +268,7 @@ string GetCpuName() {
         LOG_ERROR("error calling sysctlnametomib with machdep.cpu.brand_string, details: {}", error_str);
         return string{};
     }
-    return string(data(brand_name));
+    return string{data(brand_name)};
 }
 
 } // namespace

--- a/lib/src/platform/darwin/hardware_temperature.cpp
+++ b/lib/src/platform/darwin/hardware_temperature.cpp
@@ -24,7 +24,7 @@ using namespace std;
 
 namespace {
 
-constexpr int KERNEL_INDEX = 2;
+constexpr uint32_t KERNEL_INDEX = 2;
 
 constexpr char READ_BYTES_CMD = 5;
 constexpr char READ_KEYINFO_CMD = 9;
@@ -81,20 +81,16 @@ uint32_t BufferToNum(const KeyBuffer &buffer, int base) {
     auto buf_size = size(buffer) - 1;
     for (size_t i = 0ul; i != buf_size; ++i) {
         if (base == 16) {
-            total += buffer[i] << (buf_size - 1 - i) * 8;
+            total += static_cast<uint32_t>(buffer[i]) << ((buf_size - 1 - i) * 8);
         } else {
-            total += (static_cast<unsigned char>(buffer[i]) << (buf_size - 1 - i) * 8);
+            total += static_cast<uint32_t>(buffer[i]) << ((buf_size - 1 - i) * 8);
         }
     }
     return total;
 }
 
 KeyBuffer NumToBuffer(uint32_t value) {
-    auto str = fmt::format(FMT_STRING("{:c}{:c}{:c}{:c}"),
-                           static_cast<uint32_t>(value) >> 24,
-                           static_cast<uint32_t>(value) >> 16,
-                           static_cast<uint32_t>(value) >> 8,
-                           static_cast<uint32_t>(value));
+    auto str = fmt::format(FMT_STRING("{:c}{:c}{:c}{:c}"), value >> 24, value >> 16, value >> 8, value);
     auto buffer = KeyBuffer{};
     copy(begin(str), end(str), begin(buffer));
     return buffer;
@@ -121,7 +117,7 @@ private:
     void ReadCpuTemperature();
     void ReadGpuTemperature();
 
-    kern_return_t ConnectCall(int index, const KeyData &input, KeyData &output);
+    kern_return_t ConnectCall(uint32_t index, const KeyData &input, KeyData &output);
     kern_return_t GetKeyInfo(uint32_t key, KeyInfo &key_info);
     kern_return_t ReadKey(const KeyBuffer &key, Value &value);
     optional<double> GetSP78Value(const Value &value) const;
@@ -196,7 +192,7 @@ kern_return_t SystemManagementController::GetKeyInfo(uint32_t key, KeyInfo &key_
     return result;
 }
 
-kern_return_t SystemManagementController::ConnectCall(int index, const KeyData &input, KeyData &output) {
+kern_return_t SystemManagementController::ConnectCall(uint32_t index, const KeyData &input, KeyData &output) {
     PRECONDITIONS(service_handle_ != 0, "service handle must be valid");
     size_t input_size = sizeof(KeyData);
     size_t output_size = sizeof(KeyData);

--- a/lib/src/platform/darwin/memory.cpp
+++ b/lib/src/platform/darwin/memory.cpp
@@ -7,6 +7,7 @@
 #include "common/include/posix_error.h"
 #include "lib/include/platform/memory.h"
 
+#include <array>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -49,10 +50,10 @@ bool GetVmStat(vm_statistics64_t vmstat) {
 }
 
 optional<uint64_t> GetTotalMemory() {
-    int mib[2] = {CTL_HW, HW_MEMSIZE};
+    auto mib = array<int, 2>{CTL_HW, HW_MEMSIZE};
     auto total = uint64_t{0};
     auto len = sizeof(uint64_t);
-    if (sysctl(mib, 2, &total, &len, nullptr, 0) == -1) {
+    if (sysctl(data(mib), 2, &total, &len, nullptr, 0) == -1) {
         auto error_str = string{};
         if (auto errno_str = mmotd::error::posix_error::to_string(); !errno_str.empty()) {
             error_str = format(FMT_STRING(", details: {}"), errno_str);
@@ -75,7 +76,7 @@ optional<mmotd::platform::MemoryDetails> GetMemoryUsage() {
         return nullopt;
     }
 
-    const auto pagesize = getpagesize();
+    const auto pagesize = static_cast<uint64_t>(getpagesize());
 
     LOG_VERBOSE("pagesize: {}", pagesize);
     LOG_VERBOSE("active count: {}, {}", to_human_size(vm_statistics.active_count), vm_statistics.active_count);

--- a/lib/src/platform/darwin/processes.cpp
+++ b/lib/src/platform/darwin/processes.cpp
@@ -18,7 +18,7 @@ using namespace std;
 
 namespace {
 
-optional<size_t> GetProcessesInfoSize(int retry) {
+optional<size_t> GetProcessesInfoSize(size_t retry) {
     using namespace mmotd::error;
     auto mib = array<int, 3>{CTL_KERN, KERN_PROC, KERN_PROC_ALL};
     auto buffer_size = size_t{0};
@@ -50,9 +50,9 @@ bool GetProcessesInfoBuffer(size_t buffer_size, vector<uint8_t> &buffer) {
 }
 
 optional<vector<int32_t>> GetProcessesInfo() {
-    static constexpr int RETRY_COUNT = 6; // arbitrary retry count 1-5
+    static constexpr size_t RETRY_COUNT = 6; // arbitrary retry count 1-5
     auto process_infos = vector<kinfo_proc>{};
-    for (int i = 1; i != RETRY_COUNT && empty(process_infos); ++i) {
+    for (auto i = size_t{1}; i != RETRY_COUNT && empty(process_infos); ++i) {
         LOG_VERBOSE("getting process list #{}", i);
         auto buffer_size_wrapper = GetProcessesInfoSize(i);
         if (!buffer_size_wrapper) {

--- a/lib/src/platform/linux/system_information.cpp
+++ b/lib/src/platform/linux/system_information.cpp
@@ -1,9 +1,10 @@
 // vim: awa:sts=4:ts=4:sw=4:et:cin:fdm=manual:tw=120:ft=cpp
 #if defined(__linux__)
+#include "lib/include/platform/system_information.h"
+
 #include "common/include/iostream_error.h"
 #include "common/include/logging.h"
 #include "common/include/posix_error.h"
-#include "lib/include/platform/system_information.h"
 #include "lib/include/system_details.h"
 
 #include <filesystem>
@@ -100,7 +101,7 @@ optional<int> ParseIndividualOsVersion(string version_str) {
         return nullopt;
     }
 
-    auto offset = std::distance(begin(version_str), i);
+    auto offset = static_cast<size_t>(std::distance(begin(version_str), i));
     LOG_DEBUG("found integer offset for '{}' to be {}", version_str, offset);
     version_str = version_str.substr(offset);
 
@@ -112,7 +113,7 @@ optional<int> ParseIndividualOsVersion(string version_str) {
     auto j = find_if(begin(version_str), end(version_str), [](auto version_char) { return !is_digit()(version_char); });
 
     if (j != end(version_str)) {
-        offset = std::distance(begin(version_str), j);
+        offset = static_cast<size_t>(std::distance(begin(version_str), j));
         LOG_DEBUG("found integer offset for '{}' to be {}", version_str, offset);
         version_str = version_str.substr(0, offset);
     }


### PR DESCRIPTION
Fixing a couple TODO's within the CMake file.  The standard, and important, conversion warnings had to be disabled since I didn't add them until later in the project.  They are now re-enabled and all the warnings have been fixed.